### PR TITLE
fix: content width adjustment

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -157,43 +157,43 @@
   --space-xl-3xl: calc(((var(--fc-xl-min) / 16) * 1rem) + (var(--fc-3xl-max) - var(--fc-xl-min)) * var(--fluid-bp));
   --space-xl-4xl: calc(((var(--fc-xl-min) / 16) * 1rem) + (var(--fc-4xl-max) - var(--fc-xl-min)) * var(--fluid-bp)); }
 
-/* @link https://utopia.fyi/type/calculator?c=320,16,1.125,1280,16,1.25,6,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l */
+/* @link https://utopia.fyi/type/calculator?c=320,14,1.125,1100,16,1.25,6,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l */
 :root {
   --fluid-min-width: 320;
-  --fluid-max-width: 1280;
+  --fluid-max-width: 1100;
   --fluid-screen: 100vw;
   --fluid-bp: calc((var(--fluid-screen) - var(--fluid-min-width) / 16 * 1rem) / (var(--fluid-max-width) - var(--fluid-min-width))); }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1100px) {
   :root {
     --fluid-screen: calc(var(--fluid-max-width) * 1px); } }
 
 :root {
-  --f--2-min: 12.64;
+  --f--2-min: 11.06;
   --f--2-max: 10.24;
   --step--2: calc(((var(--f--2-min) / 16) * 1rem) + (var(--f--2-max) - var(--f--2-min)) * var(--fluid-bp));
-  --f--1-min: 14.22;
+  --f--1-min: 12.44;
   --f--1-max: 12.80;
   --step--1: calc(((var(--f--1-min) / 16) * 1rem) + (var(--f--1-max) - var(--f--1-min)) * var(--fluid-bp));
-  --f-0-min: 16.00;
+  --f-0-min: 14.00;
   --f-0-max: 16.00;
   --step-0: calc(((var(--f-0-min) / 16) * 1rem) + (var(--f-0-max) - var(--f-0-min)) * var(--fluid-bp));
-  --f-1-min: 18.00;
+  --f-1-min: 15.75;
   --f-1-max: 20.00;
   --step-1: calc(((var(--f-1-min) / 16) * 1rem) + (var(--f-1-max) - var(--f-1-min)) * var(--fluid-bp));
-  --f-2-min: 20.25;
+  --f-2-min: 17.72;
   --f-2-max: 25.00;
   --step-2: calc(((var(--f-2-min) / 16) * 1rem) + (var(--f-2-max) - var(--f-2-min)) * var(--fluid-bp));
-  --f-3-min: 22.78;
+  --f-3-min: 19.93;
   --f-3-max: 31.25;
   --step-3: calc(((var(--f-3-min) / 16) * 1rem) + (var(--f-3-max) - var(--f-3-min)) * var(--fluid-bp));
-  --f-4-min: 25.63;
+  --f-4-min: 22.43;
   --f-4-max: 39.06;
   --step-4: calc(((var(--f-4-min) / 16) * 1rem) + (var(--f-4-max) - var(--f-4-min)) * var(--fluid-bp));
-  --f-5-min: 28.83;
+  --f-5-min: 25.23;
   --f-5-max: 48.83;
   --step-5: calc(((var(--f-5-min) / 16) * 1rem) + (var(--f-5-max) - var(--f-5-min)) * var(--fluid-bp));
-  --f-6-min: 32.44;
+  --f-6-min: 28.38;
   --f-6-max: 61.04;
   --step-6: calc(((var(--f-6-min) / 16) * 1rem) + (var(--f-6-max) - var(--f-6-min)) * var(--fluid-bp)); }
 
@@ -319,7 +319,7 @@ main {
     outline: none; }
 
 .content-container {
-  max-width: 1320px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: var(--space-xl-3xl) calc(1rem + 1vw); }
 
@@ -1631,6 +1631,9 @@ ul.donation-plan__features {
 
 .span-5-8 {
   grid-column: 5 / 9; }
+
+.span-10-12 {
+  grid-column: 10 / 13; }
 
 .span-11-12 {
   grid-column: 11 / 13; }

--- a/src/assets/scss/_foundations.scss
+++ b/src/assets/scss/_foundations.scss
@@ -88,7 +88,7 @@ main {
 }
 
 .content-container {
-    max-width: 1320px;
+    max-width: 1100px;
     margin: 0 auto;
     padding: var(--space-xl-3xl) calc(1rem + 1vw);
 }

--- a/src/assets/scss/_typography.scss
+++ b/src/assets/scss/_typography.scss
@@ -1,57 +1,56 @@
-/* @link https://utopia.fyi/type/calculator?c=320,16,1.125,1280,16,1.25,6,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l */
+/* @link https://utopia.fyi/type/calculator?c=320,14,1.125,1100,16,1.25,6,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l */
 
 :root {
     --fluid-min-width: 320;
-    --fluid-max-width: 1280;
+    --fluid-max-width: 1100;
 
     --fluid-screen: 100vw;
     --fluid-bp: calc((var(--fluid-screen) - var(--fluid-min-width) / 16 * 1rem) / (var(--fluid-max-width) - var(--fluid-min-width)));
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1100px) {
     :root {
         --fluid-screen: calc(var(--fluid-max-width) * 1px);
     }
 }
 
 :root {
-    --f--2-min: 12.64;
+    --f--2-min: 11.06;
     --f--2-max: 10.24;
     --step--2: calc(((var(--f--2-min) / 16) * 1rem) + (var(--f--2-max) - var(--f--2-min)) * var(--fluid-bp));
 
-    --f--1-min: 14.22;
+    --f--1-min: 12.44;
     --f--1-max: 12.80;
     --step--1: calc(((var(--f--1-min) / 16) * 1rem) + (var(--f--1-max) - var(--f--1-min)) * var(--fluid-bp));
 
-    --f-0-min: 16.00;
+    --f-0-min: 14.00;
     --f-0-max: 16.00;
     --step-0: calc(((var(--f-0-min) / 16) * 1rem) + (var(--f-0-max) - var(--f-0-min)) * var(--fluid-bp));
 
-    --f-1-min: 18.00;
+    --f-1-min: 15.75;
     --f-1-max: 20.00;
     --step-1: calc(((var(--f-1-min) / 16) * 1rem) + (var(--f-1-max) - var(--f-1-min)) * var(--fluid-bp));
 
-    --f-2-min: 20.25;
+    --f-2-min: 17.72;
     --f-2-max: 25.00;
     --step-2: calc(((var(--f-2-min) / 16) * 1rem) + (var(--f-2-max) - var(--f-2-min)) * var(--fluid-bp));
 
-    --f-3-min: 22.78;
+    --f-3-min: 19.93;
     --f-3-max: 31.25;
     --step-3: calc(((var(--f-3-min) / 16) * 1rem) + (var(--f-3-max) - var(--f-3-min)) * var(--fluid-bp));
 
-    --f-4-min: 25.63;
+    --f-4-min: 22.43;
     --f-4-max: 39.06;
     --step-4: calc(((var(--f-4-min) / 16) * 1rem) + (var(--f-4-max) - var(--f-4-min)) * var(--fluid-bp));
 
-    --f-5-min: 28.83;
+    --f-5-min: 25.23;
     --f-5-max: 48.83;
     --step-5: calc(((var(--f-5-min) / 16) * 1rem) + (var(--f-5-max) - var(--f-5-min)) * var(--fluid-bp));
 
-    --f-6-min: 32.44;
+    --f-6-min: 28.38;
     --f-6-max: 61.04;
     --step-6: calc(((var(--f-6-min) / 16) * 1rem) + (var(--f-6-max) - var(--f-6-min)) * var(--fluid-bp));
 }
-
 
 body {
     font-size: var(--step-0);

--- a/src/assets/scss/_utilities.scss
+++ b/src/assets/scss/_utilities.scss
@@ -133,7 +133,9 @@
 }
 
 
-
+.span-10-12 {
+    grid-column: 10 / 13;
+}
 
 .span-11-12 {
     grid-column: 11 / 13;

--- a/src/content/pages/blog.html
+++ b/src/content/pages/blog.html
@@ -18,7 +18,7 @@ pagination:
                 The latest industry news, interviews, technologies, and resources.
             </p>
         </div>
-        <div class="span-11-12">
+        <div class="span-10-12">
             carbon ad here
         </div>
     </div>

--- a/src/content/pages/donate.md
+++ b/src/content/pages/donate.md
@@ -16,7 +16,7 @@ hook: "donate-page"
                 <a href="/" class="c-btn c-btn--primary">Become a sponsor</a>
             </div>
         </div>
-        <div class="span-11-12">
+        <div class="span-10-12">
             carbon ad here
         </div>
     </div>

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -33,7 +33,7 @@ eleventyExcludeFromCollections: true
             </div>
         </div>
 
-        <div class="span-11-12">
+        <div class="span-10-12">
             <!-- carbon ad here -->
 
             <dl class="eslint-versions" aria-labelledby="eslint-versions-title">

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -7,7 +7,7 @@ hook: "sponsors-page"
 
 <div class="section hero">
     <div class="content-container">
-        <div>
+        <div class="span-1-7">
             <h1 class="section-title h2">Sponsors</h1>
             <p class="section-supporting-text">
                 171 companies, organizations, and individuals are currently contributing $13137.84 each month to support ESLint's ongoing maintenance and development.
@@ -15,6 +15,9 @@ hook: "sponsors-page"
             <div class="eslint-actions">
                 <a href="/" class="c-btn c-btn--primary">Become a sponsor</a>
             </div>
+        </div>
+        <div class="span-10-12">
+            carbon ad here
         </div>
     </div>
 </div>

--- a/src/content/pages/team.html
+++ b/src/content/pages/team.html
@@ -15,7 +15,7 @@ hook: "team-page"
                 These are the people who build and maintain ESLint.
             </p>
         </div>
-        <div class="span-11-12">
+        <div class="span-10-12">
             carbon ad here
         </div>
     </div>


### PR DESCRIPTION
Changes to review:
- changed content width to 1080px 
- adjusted type scale (though that didn't have much of an effect on the width, but it makes the content look less crowded on mobile because it decreases the base font size to 14px instead of 16px)
- re-positioned the right sidebar in the hero section so it takes up more columns and thus avoids wrapping.

We still have a squishy layout in the Teams page. I'm thinking that in order to fit in this 1080px width, I'll have to adjust the font sizes used across the site on some sections + tweak component widths too.