### PR TITLE
fix: Disallow searching the site for now

### DIFF
--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -5,3 +5,4 @@ eleventyExcludeFromCollections: true
 ---
 Sitemap: {{ metadata.url }}/sitemap.xml
 User-agent: *
+Disallow: /


### PR DESCRIPTION
I just want to make sure Google isn't indexing the new site quite yet. Please double-check that I edited the correct file in the correct way. :)