### PR TITLE
fix: duplicative blog title

### DIFF
--- a/src/content/pages/blog.html
+++ b/src/content/pages/blog.html
@@ -10,13 +10,10 @@ pagination:
     size: 9
 ---
 
-
-
 <div class="blog-posts">
     {% set postItems = pagination.items %}
     {% for item in postItems %}
 
-    <!-- temporary until I can go through an update all the posts-->
     {% set author = item.data.author %}
     {% if not author %}
     {% set author = item.data.authors[0] %}


### PR DESCRIPTION
I missed that this had creeped into one of the latest pull requests. The blog page had the duplicative title issue again. This is just a fix for that.