### PR TITLE
feat: Insert ad into headers

### DIFF
--- a/src/_includes/layouts/blog.html
+++ b/src/_includes/layouts/blog.html
@@ -14,7 +14,7 @@ layout: base.html
                 </p>
             </div>
             <div class="span-11-12">
-                carbon ad here
+                {% include "partials/carbon-ad.html" %}
             </div>
         </div>
     </div>

--- a/src/_includes/layouts/category.html
+++ b/src/_includes/layouts/category.html
@@ -14,7 +14,7 @@ layout: base.html
                 </p>
             </div>
             <div class="span-11-12">
-                carbon ad here
+                {% include "partials/carbon-ad.html" %}
             </div>
         </div>
     </div>

--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -18,7 +18,7 @@ hook: "post blog-post-page"
                 </p>
             </div>
             <div class="span-11-12">
-                carbon ad here
+                {% include "partials/carbon-ad.html" %}
             </div>
         </div>
     </div>

--- a/src/_includes/partials/carbon-ad.html
+++ b/src/_includes/partials/carbon-ad.html
@@ -1,4 +1,4 @@
-<!-- <script id="eslint-sponsor">
+<script id="eslint-sponsor">
   if(window.innerWidth > 800) {
     var s = document.createElement("script");
     s.type = "text/javascript";
@@ -7,4 +7,4 @@
     document.getElementById("eslint-sponsor").after(s);
     document.getElementById("eslint-sponsor").remove();
   }
-</script> -->
+</script>

--- a/src/content/pages/branding.md
+++ b/src/content/pages/branding.md
@@ -16,7 +16,7 @@ hook: "branding-page"
             </p>
         </div>
         <div class="span-11-12">
-            carbon ad here
+                {% include "partials/carbon-ad.html" %}
         </div>
     </div>
 </section>

--- a/src/content/pages/donate.md
+++ b/src/content/pages/donate.md
@@ -14,7 +14,7 @@ hook: "donate-page"
             </p>
         </div>
         <div class="span-11-12">
-            carbon ad here
+                {% include "partials/carbon-ad.html" %}
         </div>
     </div>
 </div>

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -41,7 +41,7 @@ eleventyExcludeFromCollections: true
         </div>
 
         <div class="span-10-12 eslint-versions-col">
-            <!-- carbon ad here -->
+                {% include "partials/carbon-ad.html" %}
 
             <dl class="eslint-versions" aria-labelledby="eslint-versions-title">
                 <span id="eslint-versions-title" hidden>ESLint Versions</span>

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -8,15 +8,19 @@ hook: "sponsors-page"
 {%- from 'components/donation.macro.html' import donationItem %}
 
 <div class="section hero">
-    <div class="content-container">
-        <div>
+    <div class="content-container grid">
+        <div class="span-1-7">
             <h1 class="section-title">Sponsors</h1>
             <p class="section-supporting-text">
-                171 companies, organizations, and individuals are currently contributing $13137.84 each month to support ESLint's ongoing maintenance and development.
+                171 companies, organizations, and individuals are currently contributing $13137.84 each month to support ESLint's
+                ongoing maintenance and development.
             </p>
             <div class="eslint-actions">
                 <a href="/donate/" class="c-btn c-btn--primary">Become a sponsor</a>
             </div>
+        </div>
+        <div class="span-11-12">
+            {% include "partials/carbon-ad.html" %}
         </div>
     </div>
 </div>

--- a/src/content/pages/team.html
+++ b/src/content/pages/team.html
@@ -16,7 +16,7 @@ hook: "team-page"
             </p>
         </div>
         <div class="span-11-12">
-            carbon ad here
+                {% include "partials/carbon-ad.html" %}
         </div>
     </div>
 </section>


### PR DESCRIPTION
Before we got too far along, I wanted to get the Carbon Ads into the site to make sure we were accounting for it.

There are some things that aren't working correctly, but I was hoping you'd be able to fix them. :) They are:

1. The top of the ad needs to be higher. Starting the ad at the same height as the heading text leaves too much room above the ad and forces the whole hero area to be higher than necessary.
2. The height of the ad should not force the hero area to be taller. I think we may be able to address this by moving the top of the ad up higher, but maybe not. I'll leave that in your capable hands.

If you'd like to merge this to work on it, that's fine. You can also feel free to work directly on this branch.