### PR TITLE
feat: adjust secondary button colors in dark theme

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -68,9 +68,6 @@
   --color-brand: var(--color-primary-800); }
 
 @media (prefers-color-scheme: dark) {
-  --secondary-button-background-color: var(--color-neutral-700);
-  --secondary-button-hover-color: var(--color-neutral-800);
-  --secondary-button-text-color: var(--body-text-color);
   --body-background-color: var(--color-neutral-900);
   --body-text-color: var(--color-neutral-300);
   --headings-color: #fff;
@@ -102,9 +99,6 @@ html[data-theme="light"] {
   --outline-color: var(--color-brand); }
 
 html[data-theme="dark"] {
-  --secondary-button-background-color: var(--color-neutral-700);
-  --secondary-button-hover-color: var(--color-neutral-800);
-  --secondary-button-text-color: var(--headings-color);
   --body-background-color: var(--color-neutral-900);
   --body-text-color: var(--color-neutral-300);
   --headings-color: #fff;

--- a/src/assets/css/tokens/themes.css
+++ b/src/assets/css/tokens/themes.css
@@ -67,9 +67,6 @@
   --color-brand: var(--color-primary-800); }
 
 @media (prefers-color-scheme: dark) {
-  --secondary-button-background-color: var(--color-neutral-700);
-  --secondary-button-hover-color: var(--color-neutral-800);
-  --secondary-button-text-color: var(--body-text-color);
   --body-background-color: var(--color-neutral-900);
   --body-text-color: var(--color-neutral-300);
   --headings-color: #fff;
@@ -101,9 +98,6 @@ html[data-theme="light"] {
   --outline-color: var(--color-brand); }
 
 html[data-theme="dark"] {
-  --secondary-button-background-color: var(--color-neutral-700);
-  --secondary-button-hover-color: var(--color-neutral-800);
-  --secondary-button-text-color: var(--headings-color);
   --body-background-color: var(--color-neutral-900);
   --body-text-color: var(--color-neutral-300);
   --headings-color: #fff;

--- a/src/assets/scss/tokens/themes.scss
+++ b/src/assets/scss/tokens/themes.scss
@@ -75,9 +75,9 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    --secondary-button-background-color: var(--color-neutral-700);
-    --secondary-button-hover-color: var(--color-neutral-800);
-    --secondary-button-text-color: var(--body-text-color);
+    // --secondary-button-background-color: var(--color-neutral-700);
+    // --secondary-button-hover-color: var(--color-neutral-800);
+    // --secondary-button-text-color: var(--body-text-color);
 
     --body-background-color: var(--color-neutral-900);
     --body-text-color: var(--color-neutral-300);
@@ -122,9 +122,9 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
-    --secondary-button-background-color: var(--color-neutral-700);
-    --secondary-button-hover-color: var(--color-neutral-800);
-    --secondary-button-text-color: var(--headings-color);
+    // --secondary-button-background-color: var(--color-neutral-800);
+    // --secondary-button-hover-color: var(--color-neutral-800);
+    // --secondary-button-text-color: var(--link-color);
 
     --body-background-color: var(--color-neutral-900);
     --body-text-color: var(--color-neutral-300);


### PR DESCRIPTION
The design Heyden provided does not change the button colors between the dark and light themes. 

In dark mode, the secondary buttons look more prominent than the primary buttons (because they are light on a dark background). This PR, if you approve @nzakas , adjusts the colors of the secondary buttons (used in the homepage hero, for example), so that they look more "secondary" in dark theme.

For reference: 
The current design:
<img width="613" alt="Screen Shot 2022-01-18 at 11 27 30" src="https://user-images.githubusercontent.com/2527933/149909073-aef4bd89-9138-4fbe-844f-16e12b98e7a3.png">

and the adjustment I'm suggesting: 
<img width="653" alt="Screen Shot 2022-01-18 at 11 27 10" src="https://user-images.githubusercontent.com/2527933/149909114-a736b84a-703c-4f74-bb1e-25eb92379dc0.png"> 