### PR TITLE
fix: logo changer buttons in dark mode

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1292,9 +1292,7 @@ ul.donation-plan__features,
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1rem;
-  margin-block-end: 1rem;
-  border-radius: var(--border-radius); }
+  border-radius: var(--border-radius) var(--border-radius) 0 0; }
   .brand__logo__img[data-brand-theme="light"] {
     background-color: var(--color-neutral-100); }
   .brand__logo__img[data-brand-theme="brand"] {
@@ -1304,12 +1302,16 @@ ul.donation-plan__features,
 
 .brand__logo__colors {
   display: flex;
-  align-items: center; }
+  align-items: center;
+  background-color: #fff;
+  padding: 1rem;
+  color: var(--color-neutral-900);
+  border-radius: 0 0 var(--border-radius) var(--border-radius); }
 
 .brand__logo__colors__btn {
   display: inline-block;
-  width: 1rem;
-  height: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
   padding: 0;
   flex: none;
   margin-left: .75rem;
@@ -1328,6 +1330,7 @@ ul.donation-plan__features,
     box-shadow: 0px 4px 8px -2px rgba(16, 24, 40, 0.1), 0px 4px 6px -2px rgba(16, 24, 40, 0.05);
     display: none;
     background-color: var(--lightest-background-color);
+    color: var(--headings-color);
     border-radius: .25rem;
     padding: .25rem .75rem; }
   .brand__logo__colors__btn:hover::before {

--- a/src/assets/scss/_branding.scss
+++ b/src/assets/scss/_branding.scss
@@ -11,9 +11,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 1rem;
-    margin-block-end: 1rem;
-    border-radius: var(--border-radius);
+    // margin-bottom: 1rem;
+    // margin-block-end: 1rem;
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
 
     &[data-brand-theme="light"] {
         background-color: var(--color-neutral-100);
@@ -31,12 +31,18 @@
 .brand__logo__colors {
     display: flex;
     align-items: center;
+
+    background-color: #fff;
+    padding: 1rem;
+    color: var(--color-neutral-900);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
 .brand__logo__colors__btn {
     display: inline-block;
-    width: 1rem;
-    height: 1rem;
+    // border: 1px solid #fff;
+    width: 1.25rem;
+    height: 1.25rem;
     padding: 0;
     flex: none;
     margin-left: .75rem;
@@ -58,6 +64,7 @@
         0px 4px 6px -2px rgba(16, 24, 40, 0.05);
         display: none;
         background-color: var(--lightest-background-color);
+        color: var(--headings-color);
         border-radius: .25rem;
         padding: .25rem .75rem;
     }


### PR DESCRIPTION
Applies a background color to the logo changer buttons to avoid the dark mode background color clashing with the button color.