### PR TITLE
fix: alert inner spacing and background color in dark mode

### DIFF
--- a/src/_includes/components/alert.macro.html
+++ b/src/_includes/components/alert.macro.html
@@ -6,7 +6,6 @@
     <div class="alert__content">
         <span class="alert__type">Warning</span>
         <div class="alert__text">{{ params.text }}</div>
-
         <a href="{{ params.url }}" class="alert__learn-more">Learn more</a>
     </div>
 
@@ -27,7 +26,6 @@
     <div class="alert__content">
         <span class="alert__type">Important</span>
         <div class="alert__text">{{ params.text }}</div>
-
         <a href="{{ params.url }}" class="alert__learn-more">Learn more</a>
     </div>
 
@@ -48,7 +46,6 @@
     <div class="alert__content">
         <span class="alert__type">Tip</span>
         <div class="alert__text">{{ params.text }}</div>
-
         <a href="{{ params.url }}" class="alert__learn-more">Learn more</a>
     </div>
 

--- a/src/assets/css/components/alert.css
+++ b/src/assets/css/components/alert.css
@@ -8,6 +8,7 @@
   margin-block-end: 1.5rem;
   align-items: start;
   font-size: .875rem;
+  background-color: #fff;
   border-radius: var(--border-radius); }
   .alert.alert--warning {
     border: 1px solid var(--color-rose-300); }

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -2194,6 +2194,7 @@ button.c-share__btn {
   margin-block-end: 1.5rem;
   align-items: start;
   font-size: .875rem;
+  background-color: #fff;
   border-radius: var(--border-radius); }
   .alert.alert--warning {
     border: 1px solid var(--color-rose-300); }

--- a/src/assets/scss/components/alert.scss
+++ b/src/assets/scss/components/alert.scss
@@ -8,6 +8,7 @@
     margin-block-end: 1.5rem;
     align-items: start;
     font-size: .875rem;
+    background-color: #fff;
     border-radius: var(--border-radius);
 
     &.alert--warning {

--- a/src/assets/scss/components/docs-resources.scss
+++ b/src/assets/scss/components/docs-resources.scss
@@ -1,0 +1,48 @@
+.resource {
+    display: flex;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--divider-color);
+    background-color: var(--lightest-background-color);
+    align-items: stretch;
+    overflow: hidden;
+    margin-bottom: .5rem;
+    margin-block-end: .5rem;
+}
+
+.resource__image {
+    flex: 1 1 5rem;
+    max-width: 5rem;
+    // height: 100%;
+    overflow: hidden;
+
+    img {
+        display: block;
+        height: 100%;
+        width: 100%;
+        object-fit: contain;
+    }
+}
+
+.resource__content {
+    flex: 4;
+    padding: .75rem;
+    align-self: center;
+}
+
+.resource__title {
+    text-decoration: none;
+    color: var(--headings-color);
+    font-weight: 500;
+    margin-bottom: .125rem;
+}
+
+.resource__domain {
+    color: var(--body-text-color);
+    font-size: .875rem;
+}
+
+.resource__icon {
+    color: var(--headings-color);
+    margin: 1rem;
+    align-self: center;
+}


### PR DESCRIPTION
I added a white background color to the alert banners (can be seen in the component library) because otherwise the red, orange, and green colors don't have enough contrast with the dark background color of the dark theme.

I also removed an extra margin that was being added to the bottom of the alert.