### PR TITLE
feat: separate theme switcher buttons visually

### DIFF
--- a/src/assets/css/components/theme-switcher.css
+++ b/src/assets/css/components/theme-switcher.css
@@ -1,18 +1,17 @@
 .theme-switcher {
   display: inline-flex;
   align-items: center;
-  gap: .5rem; }
+  gap: .5rem;
+  position: relative; }
 
 .theme-switcher__buttons {
   display: flex;
-  gap: .25rem;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   background-color: var(--body-background-color); }
 
 .theme-switcher__button {
   flex: 0;
-  border-radius: var(--border-radius);
   box-shadow: var(--shadow-xs);
   padding: .625rem .875rem;
   display: inline-flex;
@@ -20,6 +19,12 @@
   margin: 0;
   width: 40px;
   height: 40px; }
+  .theme-switcher__button:first-of-type {
+    border-right: 0.5px solid var(--border-color);
+    border-inline-end: 0.5px solid var(--border-color); }
+  .theme-switcher__button:last-of-type {
+    border-left: 0.5px solid var(--border-color);
+    border-inline-start: 0.5px solid var(--border-color); }
   .theme-switcher__button .theme-switcher__icon {
     color: var(--icon-color); }
   .theme-switcher__button:hover .theme-switcher__icon {

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -2809,18 +2809,17 @@ a.rule__name {
 .theme-switcher {
   display: inline-flex;
   align-items: center;
-  gap: .5rem; }
+  gap: .5rem;
+  position: relative; }
 
 .theme-switcher__buttons {
   display: flex;
-  gap: .25rem;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   background-color: var(--body-background-color); }
 
 .theme-switcher__button {
   flex: 0;
-  border-radius: var(--border-radius);
   box-shadow: var(--shadow-xs);
   padding: .625rem .875rem;
   display: inline-flex;
@@ -2828,6 +2827,12 @@ a.rule__name {
   margin: 0;
   width: 40px;
   height: 40px; }
+  .theme-switcher__button:first-of-type {
+    border-right: 0.5px solid var(--border-color);
+    border-inline-end: 0.5px solid var(--border-color); }
+  .theme-switcher__button:last-of-type {
+    border-left: 0.5px solid var(--border-color);
+    border-inline-start: 0.5px solid var(--border-color); }
   .theme-switcher__button .theme-switcher__icon {
     color: var(--icon-color); }
   .theme-switcher__button:hover .theme-switcher__icon {

--- a/src/assets/scss/components/theme-switcher.scss
+++ b/src/assets/scss/components/theme-switcher.scss
@@ -3,11 +3,11 @@
     display: inline-flex;
     align-items: center;
     gap: .5rem;
+    position: relative;
 }
 
 .theme-switcher__buttons {
     display: flex;
-    gap: .25rem;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     background-color: var(--body-background-color);
@@ -15,9 +15,7 @@
 
 .theme-switcher__button {
     flex: 0;
-    border-radius: var(--border-radius);
     box-shadow: var(--shadow-xs);
-    // border: 1px solid var(--border-color);
     padding: .625rem .875rem;
     display: inline-flex;
     align-items: center;
@@ -25,9 +23,20 @@
     width: 40px;
     height: 40px;
 
+    &:first-of-type {
+        border-right: .5px solid var(--border-color);
+        border-inline-end: .5px solid var(--border-color);
+    }
+
+    &:last-of-type {
+        border-left: .5px solid var(--border-color);
+        border-inline-start: .5px solid var(--border-color);
+    }
+
     .theme-switcher__icon {
         color: var(--icon-color);
     }
+
     &:hover {
         .theme-switcher__icon {
             color: var(--link-color);


### PR DESCRIPTION
I added a border between the theme switcher button just so that they look more like two separate buttons (as opposed to, for example, two options of one thing, like radio buttons).