### PR TITLE
fix: Make sure category shows on blog posts

### DIFF
--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -12,7 +12,7 @@ hook: "post blog-post-page"
     {% set hero_title = title %}
     {% set hero_supporting_text = teaser %}
     {% set hero_date = page.date | readableDate %}
-    {% set hero_category = page.categories %}
+    {% set hero_category = categories[0] %}
     {% set hero_category_url = categories[0] | slugify %}
 
     {{ hero({


### PR DESCRIPTION
I noticed that the category wasn't showing up on individual blog post pages. I think this may have been a result of a recent refactor? In any event, this fixes it.