### PR TITLE
feat!: Switch domain name to eslint.org

### DIFF
--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -14,7 +14,7 @@ language:
   flag: 🇺🇸
   name: English (US)
 locale: en-US
-hostname: new.eslint.org
+hostname: eslint.org
 
 #------------------------------------------------------------------------------
 # Analytics


### PR DESCRIPTION
For when we do the final switchover.