### PR TITLE
fix: Ensure landing page h1 element is exposed to assistive technologies

### DIFF
--- a/src/_includes/components/header-animation.njk
+++ b/src/_includes/components/header-animation.njk
@@ -7,11 +7,11 @@
   <div class="anim__cursorCont" aria-hidden="true">
     <div class="anim__cursor anim__cursor--start"></div>
   </div>
-  <h1 class="section-title h0 anim__title" aria-hidden="true">
-
+  <h1 class="section-title h0 anim__title">
+	<span class="visually-hidden">{{ site.homepage.animation.text }}</span>
     {% for word in words %}
       {% if word == site.homepage.animation.highlight_word %}
-        <span class="anim__word anim__problems">
+        <span class="anim__word anim__problems" aria-hidden="true">
           <span class="anim__text">{{ word }}</span>
           <div class="anim__dropdown">
             <img class="anim__dropdown-img anim__dropdown-img--dark" src="/assets/images/dropdown--dark.png" alt="" />
@@ -20,7 +20,7 @@
           </div>
         </span>
       {% else %}
-        <span class="anim__word">{{ word }}</span>
+        <span class="anim__word" aria-hidden="true">{{ word }}</span>
       {% endif %}
     {% endfor %}
   </h1>

--- a/src/_includes/components/header-animation.njk
+++ b/src/_includes/components/header-animation.njk
@@ -7,11 +7,11 @@
   <div class="anim__cursorCont" aria-hidden="true">
     <div class="anim__cursor anim__cursor--start"></div>
   </div>
-  <h1 class="section-title h0 anim__title">
-	<span class="visually-hidden">{{ site.homepage.animation.text }}</span>
+  <h1 class="section-title h0 anim__title" aria-hidden="true">
+
     {% for word in words %}
       {% if word == site.homepage.animation.highlight_word %}
-        <span class="anim__word anim__problems" aria-hidden="true">
+        <span class="anim__word anim__problems">
           <span class="anim__text">{{ word }}</span>
           <div class="anim__dropdown">
             <img class="anim__dropdown-img anim__dropdown-img--dark" src="/assets/images/dropdown--dark.png" alt="" />
@@ -20,7 +20,7 @@
           </div>
         </span>
       {% else %}
-        <span class="anim__word" aria-hidden="true">{{ word }}</span>
+        <span class="anim__word">{{ word }}</span>
       {% endif %}
     {% endfor %}
   </h1>

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
         <div class="span-1-7 content-container">
             <div class="">
                 <div class="section-head">
-			{% if site.homepage.animation.enabled %}
+		{% if site.homepage.animation.enabled %}
                     	<h1 class="visually-hidden">{{ site.homepage.title }}</h1>
                         {% include 'components/header-animation.njk' %}
                     {% else %}

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
         <div class="span-1-7 content-container">
             <div class="">
                 <div class="section-head">
-					{% if site.homepage.animation.enabled %}
+			{% if site.homepage.animation.enabled %}
                     	<h1 class="visually-hidden">{{ site.homepage.title }}</h1>
                         {% include 'components/header-animation.njk' %}
                     {% else %}

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -17,8 +17,8 @@ eleventyExcludeFromCollections: true
         <div class="span-1-7 content-container">
             <div class="">
                 <div class="section-head">
-                    <h1 class="visually-hidden">{{title}}</h1>
-                    {% if site.homepage.animation.enabled %}
+					{% if site.homepage.animation.enabled %}
+                    	<h1 class="visually-hidden">{{ site.homepage.title }}</h1>
                         {% include 'components/header-animation.njk' %}
                     {% else %}
                         <h1 class="section-title">{{ site.homepage.title }}</h1>


### PR DESCRIPTION
Currently, the eslint.org landing page's "Find and fix problems in your JavaScript code" `<h1>` is not exposed at all to assistive technologies such as screenreaders. From what I can tell, this seems to be out of a desire to not burden screenreader users with the red-squiggly-fixing animation, but it means that screenreader users don't get access to the heading contents at all.

To remedy this, I've removed the `aria-hidden` from the `<h1>`, and instead placed it on each of the animated child nodes. Additionally, I've added a visually-hidden span which contains the full, unbroken text contents of the heading.