### PR TITLE
chore: Improve Carbon ad style

### DIFF
--- a/src/assets/scss/components/carbon-ads.scss
+++ b/src/assets/scss/components/carbon-ads.scss
@@ -18,11 +18,10 @@
 
 #carbonads {
     display: inline-block;
-    margin: 2rem 0;;
+    margin: 2rem 0;
     padding: .6em;
 
-    font-size: 16px;
-    line-height: 1.35;
+    font-size: 1rem;
     overflow: hidden;
     border-radius: 4px;
     background-color: var(--body-background-color);
@@ -47,11 +46,12 @@
 #carbonads a {
     font-weight: 500;
     color: inherit;
+    text-decoration: none;
 }
 
 #carbonads a:hover {
     text-decoration: none;
-    color: inherit;
+    color: var(--link-color);
 }
 
 .jumbotron #carbonads a {
@@ -83,16 +83,19 @@
 #carbonads .carbon-text {
     margin-top: 10px;
 
-    font-size: 14px;
+    line-height: calc(1.2em + .5ex);
+    font-size: .7em;
+    font-weight: 500;
     text-align: left;
 }
 
 #carbonads .carbon-poweredby {
     display: block;
     margin-top: 10px;
-    font-size: 10px;
+    font-size: .5em;
+    font-weight: 600;
     line-height: 1;
-    letter-spacing: 1px;
+    letter-spacing: .1ch;
     text-transform: uppercase;
 }
 


### PR DESCRIPTION
Minor adjustment to the style to match the site overall theme.
- Remove the text underline
- Set the font-size smaller with dynamic line-height
- Set the hover color to match the CSS `--link-color`

@nzakas kindly review and feel free to make adjusment as needed.

![](https://share.cleanshot.com/QBkb2u+)