### PR TITLE
chore: Ensure authors are never overwritten

### DIFF
--- a/src/_data/all_authors.json
+++ b/src/_data/all_authors.json
@@ -119,5 +119,16 @@
         "twitter_username": null,
         "github_username": "mdjermanovic",
         "location": null
+    },
+    "eslintbot": {
+        "username": "eslintbot",
+        "name": "ESLint Bot",
+        "title": "Automation Bot",
+        "website": "https://eslint.org",
+        "avatar_url": "https://avatars.githubusercontent.com/u/13383618?v=4",
+        "bio": null,
+        "twitter_username": "geteslint",
+        "github_username": "eslintbot",
+        "location": null
     }
 }

--- a/tools/fetch-team-data.js
+++ b/tools/fetch-team-data.js
@@ -166,8 +166,14 @@ async function fetchBlogAuthors() {
         fetchBlogAuthors()
     ]);
 
+    const existingAuthors = JSON.parse(await fs.readFile(authorsFilename, "utf8"));
+    const allAuthors = {
+        ...existingAuthors,
+        ...authors
+    };
+
     await fs.writeFile(teamFilename, JSON.stringify(team, null, "    "), { encoding: "utf8" });
-    await fs.writeFile(authorsFilename, JSON.stringify(authors, null, "    "), { encoding: "utf8" });
+    await fs.writeFile(authorsFilename, JSON.stringify(allAuthors, null, "    "), { encoding: "utf8" });
 
     console.log("Fetch Team Data: Success");
 })();


### PR DESCRIPTION
This ensures that existing authors are never deleted from the `all_authors.json` file. Also restored the `eslintbot` entry.

Fixes #238