### PR TITLE
fix: set reference to view_all_posts

### DIFF
--- a/src/_includes/partials/from-the-blog.html
+++ b/src/_includes/partials/from-the-blog.html
@@ -9,7 +9,7 @@
                     {{ site.blog_page.description }}
                 </p>
             </header>
-            <div class="span-11-12"><a href="{{ links.blog }}" class="c-btn c-btn--primary c-btn--block from-the-blog__more">View all posts</a></div>
+            <div class="span-11-12"><a href="{{ links.blog }}" class="c-btn c-btn--primary c-btn--block from-the-blog__more">{{ site.homepage.blog.view_all_posts }}</a></div>
         </div>
 
         <div class="blog-posts">


### PR DESCRIPTION
Just changing the hard-coded word "View all posts" by: view_all_posts for blog page