### PR TITLE
feat: optimize share url button

### DIFF
--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -152,13 +152,13 @@
 }
 
 .share-url {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 1rem;
     background-color: var(--lightest-background-color);
     border-radius: var(--border-radius);
     border: 1px solid var(--border-color);
-    padding-right: calc(.625rem + 1vw);
+    padding-right: calc(.625rem + 20px);
 
     max-width: 100%;
     color: var(--headings-color);
@@ -174,8 +174,9 @@
 
     input {
         all: unset;
+        flex-grow: 1;
         color: inherit;
-        padding: .625rem calc(.625rem + 1vw) .625rem .875rem;
+        padding: .625rem .625rem .625rem .875rem;
         white-space: nowrap;
         overflow-x: auto;
         overflow: hidden;


### PR DESCRIPTION
Not sure why the share url button is not extended to full width in this case,

1. it's sort of small, I can only see `https://eslint.org/play/#e`,
2. the `vw` is not consistent, it's changing with the size of viewport, and could cause overlapping problem between the texts and copy button, you can see it from the first screenshot

![image](https://user-images.githubusercontent.com/1091472/181866014-0efb9fda-3f7a-41b7-81e3-fbd55f92f0fb.png)

Thus I'm proposing some changes to the share url button.