### PR TITLE
build: enable webpack persistent cache

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,13 @@ module.exports = {
         filename: "[name].js",
         path: path.resolve(__dirname, "_site/assets/js")
     },
+    cache: {
+        type: "filesystem",
+        buildDependencies: {
+            config: [__filename]
+        },
+        cacheDirectory: path.resolve(__dirname, "node_modules/.cache/webpack")
+    },
     resolve: {
         extensions: [".js", ".jsx"],
         mainFields: ["browser", "main", "module"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,7 @@ module.exports = {
         type: "filesystem",
         buildDependencies: {
             config: [__filename]
-        },
-        cacheDirectory: path.resolve(__dirname, "node_modules/.cache/webpack")
+        }
     },
     resolve: {
         extensions: [".js", ".jsx"],


### PR DESCRIPTION
Related docs - https://webpack.js.org/configuration/cache/

With cache, the webpack re-build time is now reduced from `12349 ms` to `323 ms`. 

Initial build without cache:
<img width="390" alt="Screenshot 2022-07-30 at 9 51 56 AM" src="https://user-images.githubusercontent.com/46647141/181872318-82bff12c-028c-4177-822c-d812285812b7.png">

Re-build with cache
<img width="373" alt="Screenshot 2022-07-30 at 9 52 11 AM" src="https://user-images.githubusercontent.com/46647141/181872324-9eb59bfb-a854-4d2c-b6ed-63dc0a86081e.png">
