### PR TITLE
fix: Uncaught TypeError: Cannot read properties of null (reading 'setAttribute')

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -125,7 +125,9 @@
             });
         }
     </script>
+    {% if page.url != '/play/' %} 
     <script src="{{ '/assets/js/themes.js' | url }}"></script>
+    {%- endif -%}
     {%- if (hook == "blog_page") -%}
     <script type="module" src="{{ '/assets/js/search.js' | url }}"></script>
     {%- endif -%}


### PR DESCRIPTION
TypeError on the playground page is fixed. for #298 