### PR TITLE
feat: Use property language names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19789,7 +19789,6 @@
             "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.5.1.tgz",
             "integrity": "sha512-90SNE89uJOQgcZwV0fuZjCgDeH7pjagCqwOcYHvDG5Qedp2nKmb4/2mgDCtLBxTGKxb73ktUOkbdu3L05ck1Yg==",
             "requires": {
-                "@babel/runtime": "^7.17.2",
                 "@codemirror/basic-setup": "^0.19.1",
                 "@codemirror/state": "^0.19.9",
                 "@codemirror/theme-one-dark": "^0.19.1",

--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -12,7 +12,8 @@
 language:
   code: de
   flag: 🇩🇪
-  name: German (DE)
+  name: Deutsch
+  title: German
 locale: de-DE
 hostname: de.eslint.org
 

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -13,6 +13,7 @@ language:
   code: en
   flag: 🇺🇸
   name: English (US)
+  title: English (US)
 locale: en-US
 hostname: eslint.org
 

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -12,7 +12,8 @@
 language:
   code: hi
   flag: 🇮🇳
-  name: Hindi (In)
+  name: हिन्दी
+  title: Hindi (IN)
 locale: hi-IN
 hostname: hi.eslint.org
 

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -12,7 +12,8 @@
 language:
   code: pt-br
   flag: 🇧🇷
-  name: Portuguese (BR)
+  name: Português (BR)
+  title: Portuguese (BR)
 locale: pt-BR
 hostname: pt-br.eslint.org
 

--- a/src/_data/sites/zh-cn.yml
+++ b/src/_data/sites/zh-cn.yml
@@ -10,11 +10,12 @@
 #------------------------------------------------------------------------------
 
 language:
-  code: zh-cn
+  code: zh-hans
   flag: 🇨🇳
   name: 简体中文
-locale: zh-cn
-hostname: new.cn.eslint.org
+  title: Simplified Chinese
+locale: zh-hans
+hostname: zh-hans.eslint.org
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_includes/components/language-switcher.html
+++ b/src/_includes/components/language-switcher.html
@@ -13,6 +13,7 @@
         <select name="language selector" id="language-select" aria-describedby="language-infobox" class="c-custom-select switcher__select">
             {% for key, other_site in sites %}
             <option value="{{ other_site.language.code }}"
+                    title="{{ other_site.language.title }}" 
                     data-url="https://{{ other_site.hostname }}"
                     {% if site.language.code == other_site.language.code %} selected {% endif %}>
                 {{ other_site.language.flag }} {{ other_site.language.name }}

--- a/src/_includes/partials/languages-list.html
+++ b/src/_includes/partials/languages-list.html
@@ -1,5 +1,5 @@
 <ul class="languages-list">
     {%- for key, other_site in sites -%}
-    <li lang="{{ other_site.language.code }}"><a href="https://{{ other_site.hostname }}" {% if site.language.code == other_site.language.code %} aria-current="true" {% endif %}><span class="flag">{{ other_site.language.flag }}</span> {{ other_site.language.name }}</a></li>
+    <li lang="{{ other_site.language.code }}" title="{{ other_site.language.title }}"><a href="https://{{ other_site.hostname }}" {% if site.language.code == other_site.language.code %} aria-current="true" {% endif %}><span class="flag">{{ other_site.language.flag }}</span> {{ other_site.language.name }}</a></li>
     {%- endfor -%}
 </ul>


### PR DESCRIPTION
This uses the property language names in the dropdown and languages list while providing an English-language fallback as the `title` attribute.