### PR TITLE
feat: add keyboard controls to blog search

### DIFF
--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -144,12 +144,6 @@ searchInput.addEventListener('keyup', function (e) {
     searchQuery = query
 });
 
-resultsElement.addEventListener('keydown', function(e) {
-    if(e.key === "Escape") {
-        clearSearchResults();
-    }
-}, true);
-
 searchClearBtn.addEventListener('click', function(e) {
     searchInput.value = '';
     searchInput.focus();
@@ -170,6 +164,10 @@ searchInput.addEventListener('keydown', function (e) {
             break;
         case "Enter":
             resultsElement.querySelector('li.selected a').click();
+            break;
+        case "Escape":
+            e.preventDefault();
+            clearSearchResults();
             break;
 
         default:

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -181,3 +181,11 @@ searchInput.addEventListener('keydown', function(e) {
         maintainScrollVisibility(activeSearchResult, resultsElement);
     }
 });
+
+document.addEventListener('keydown',function (e){
+    if((e.metaKey || e.ctrlKey) && e.key === 'k'){
+        e.preventDefault();
+        searchInput.focus();
+        document.querySelector('.search').scrollIntoView({behaviour:"smooth",block: "start"});
+    }
+});

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -170,8 +170,6 @@ searchInput.addEventListener('keydown', function (e) {
             clearSearchResults();
             break;
 
-        default:
-            break;
     }
     if (activeIndex === -1) return;
     const activeSearchResult = searchResults[activeIndex];

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -150,7 +150,7 @@ searchClearBtn.addEventListener('click', function(e) {
     clearSearchResults();
 });
 
-searchInput.addEventListener('keydown', function (e) {
+searchInput.addEventListener('keydown', function(e) {
     const searchResults = Array.from(document.querySelectorAll('.search-results__item'));
     if (!searchResults.length) return;
     switch (e.key) {
@@ -169,8 +169,8 @@ searchInput.addEventListener('keydown', function (e) {
             e.preventDefault();
             clearSearchResults();
             break;
-
     }
+
     if (activeIndex === -1) return;
     const activeSearchResult = searchResults[activeIndex];
     searchResults.forEach(result => {

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -150,9 +150,23 @@ searchClearBtn.addEventListener('click', function(e) {
     clearSearchResults();
 });
 
-searchInput.addEventListener('keydown', function(e) {
+document.addEventListener('keydown', function(e) {
+
+    if(e.key === 'Escape'){
+        e.preventDefault();
+        clearSearchResults();
+        searchInput.focus();
+    }
+
+    if((e.metaKey || e.ctrlKey) && e.key === 'k'){
+        e.preventDefault();
+        searchInput.focus();
+        document.querySelector('.search').scrollIntoView({behaviour:"smooth",block: "start"});
+    }
+
     const searchResults = Array.from(document.querySelectorAll('.search-results__item'));
     if (!searchResults.length) return;
+
     switch (e.key) {
         case "ArrowUp":
             e.preventDefault();
@@ -162,30 +176,12 @@ searchInput.addEventListener('keydown', function(e) {
             e.preventDefault();
             activeIndex = activeIndex + 1 < searchResults.length ? activeIndex + 1 : 0;
             break;
-        case "Enter":
-            resultsElement.querySelector('li.selected a').click();
-            break;
-        case "Escape":
-            e.preventDefault();
-            clearSearchResults();
-            break;
     }
 
     if (activeIndex === -1) return;
     const activeSearchResult = searchResults[activeIndex];
-    searchResults.forEach(result => {
-        result.classList.remove('selected');
-    });
-    activeSearchResult.classList.add('selected');
+    activeSearchResult.querySelector('a').focus();
     if (isScrollable(resultsElement)) {
         maintainScrollVisibility(activeSearchResult, resultsElement);
-    }
-});
-
-document.addEventListener('keydown',function (e){
-    if((e.metaKey || e.ctrlKey) && e.key === 'k'){
-        e.preventDefault();
-        searchInput.focus();
-        document.querySelector('.search').scrollIntoView({behaviour:"smooth",block: "start"});
     }
 });

--- a/src/assets/scss/components/search.scss
+++ b/src/assets/scss/components/search.scss
@@ -110,6 +110,10 @@
     &:hover {
         background-color: var(--lightest-background-color);
     }
+
+    &.selected{
+        background-color: var(--lightest-background-color);
+    }
 }
 
 .search .search-results__item__title {
@@ -160,3 +164,4 @@
         color: var(--color-neutral-900);
     }
 }
+

--- a/src/assets/scss/components/search.scss
+++ b/src/assets/scss/components/search.scss
@@ -110,8 +110,8 @@
     &:hover {
         background-color: var(--lightest-background-color);
     }
-
-    &.selected{
+    
+    &:focus-within{
         background-color: var(--lightest-background-color);
     }
 }


### PR DESCRIPTION
- Added keyboard navigation of blog search results using `ArrowUp` and `ArrowDown`
- Pressing `Enter` on selected result will open the selected page
- Pressing `Esc` key will close the search results dropdown and focuses the input
- Added `⌘ + K` key binding to focus the search field

Closes #309 