### PR TITLE
feat: make card cover can't reachable via `Tab`

### DIFF
--- a/src/_includes/components/card.macro.html
+++ b/src/_includes/components/card.macro.html
@@ -22,7 +22,7 @@
     {%- set img = ['/assets/images/blog-covers/', imageName] | join  -%}
     {%- set image_path = ["/blog-covers/", imageName] | join -%}
     {%- set image_alt = params.title -%}
-    <a href="{{ params.url }}" class="card__cover">
+    <a href="{{ params.url }}" class="card__cover" tabindex="-1">
         {%- image image_path, params.title -%}
     </a>
     <div class="card__content">


### PR DESCRIPTION
Previously both cover and title could be reachable via keyboard navigation, but in fact both pointed to the same link. This is not accessibility friendly. Let's focus only on the more important title.

![image](https://user-images.githubusercontent.com/45708948/185860825-7b4808a3-9e5d-4cec-92e1-dfd41291f22f.png)
---

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/45708948/185859968-cb7dc7ad-b223-43ac-90aa-051bbf4cb192.gif) | ![after](https://user-images.githubusercontent.com/45708948/185860014-60d0abbb-4dd6-4865-80c0-e07357a10a71.gif) |