### PR TITLE
fix: ESM import syntax in blog post

### DIFF
--- a/src/content/blog/2022-08-08-new-config-system-part-3.md
+++ b/src/content/blog/2022-08-08-new-config-system-part-3.md
@@ -76,7 +76,8 @@ Similar to the `ESLint` class, there was no easy way to provide an option to swi
 
 ```js
 // ESM
-import { FlatRuleTester } from "eslint/use-at-your-own-risk";
+import pkg from "eslint/use-at-your-own-risk";
+const { FlatRuleTester } = pkg;
 
 // CommonJS
 const { FlatRuleTester } = require("eslint/use-at-your-own-risk");

--- a/src/content/blog/2022-08-08-new-config-system-part-3.md
+++ b/src/content/blog/2022-08-08-new-config-system-part-3.md
@@ -46,7 +46,8 @@ For now, you can access `FlatESLint` through the `use-at-your-own-risk` entrypoi
 
 ```js
 // ESM
-import { FlatESLint } from "eslint/use-at-your-own-risk";
+import pkg from "eslint/use-at-your-own-risk";
+const { FlatESLint } = pkg;
 
 // CommonJS
 const { FlatESLint } = require("eslint/use-at-your-own-risk");


### PR DESCRIPTION
Corrects the syntax for importing FlatESLint. 