### PR TITLE
fix: update css selector for anchors

### DIFF
--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -10,7 +10,7 @@ hook: "post blog-post-page"
 <script src="https://unpkg.com/anchor-js@4.3.1/anchor.min.js" type="text/javascript"></script>
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    anchors.add(".post h2, .post h3, .post h4");
+    anchors.add(".post__blog-content h2, .post__blog-content h3, .post__blog-content h4");
 });
 </script>
 <main id="main"  class="post-main" tabindex="-1">


### PR DESCRIPTION
This seems to be a mistake where anchors were generated for sidebar headings as well (those red ones).

![](https://user-images.githubusercontent.com/1091472/190178289-3fe16744-5f6d-4c45-b6dc-ac3cdd023be3.png)

I think it should only target the blog content, i.e., the green part.