### PR TITLE
feat: Add zh-hans docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21460,7 +21460,6 @@
             "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.5.1.tgz",
             "integrity": "sha512-90SNE89uJOQgcZwV0fuZjCgDeH7pjagCqwOcYHvDG5Qedp2nKmb4/2mgDCtLBxTGKxb73ktUOkbdu3L05ck1Yg==",
             "requires": {
-                "@babel/runtime": "^7.17.2",
                 "@codemirror/basic-setup": "^0.19.1",
                 "@codemirror/state": "^0.19.9",
                 "@codemirror/theme-one-dark": "^0.19.1",

--- a/src/_data/links.json
+++ b/src/_data/links.json
@@ -5,16 +5,16 @@
     "group": "https://groups.google.com/group/eslint",
 
     "blog": "/blog",
-    "docs": "https://eslint.org/docs",
+    "docs": "/docs",
     "playground": "/play",
-    "getStarted": "https://eslint.org/docs/user-guide/getting-started",
+    "getStarted": "/docs/user-guide/getting-started",
     "sponsors": "/sponsors",
     "branding": "/branding",
     "store": "https://eslint.threadless.com",
     "team": "/team",
 
-    "configuring": "https://eslint.org/docs/user-guide/configuring/",
-    "fixProblems": "https://eslint.org/docs/user-guide/command-line-interface#fixing-problems",
+    "configuring": "/docs/user-guide/configuring/",
+    "fixProblems": "/docs/user-guide/command-line-interface#fixing-problems",
 
     "donate": "/donate",
     "openCollective": "https://opencollective.com/eslint",

--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -16,6 +16,9 @@ language:
   title: German
 locale: de-DE
 hostname: de.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -17,7 +17,8 @@ language:
 locale: de-DE
 hostname: de.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -17,7 +17,8 @@ language:
 locale: en-US
 hostname: eslint.org
 locals:
-  docs: docs-eslint.netlify.app
+  docs_latest: latest--docs-eslint.netlify.app
+  docs_head: docs-eslint.netlify.app
   blog: true
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -16,6 +16,9 @@ language:
   title: English (US)
 locale: en-US
 hostname: eslint.org
+locals:
+  docs: docs-eslint.netlify.app
+  blog: true
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/es.yml
+++ b/src/_data/sites/es.yml
@@ -16,6 +16,9 @@ language:
   title: Spanish
 locale: es-ES
 hostname: es.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/es.yml
+++ b/src/_data/sites/es.yml
@@ -17,7 +17,8 @@ language:
 locale: es-ES
 hostname: es.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/fr.yml
+++ b/src/_data/sites/fr.yml
@@ -17,7 +17,8 @@ language:
 locale: fr-FR
 hostname: fr.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/fr.yml
+++ b/src/_data/sites/fr.yml
@@ -16,6 +16,9 @@ language:
   title: French
 locale: fr-FR
 hostname: fr.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -17,7 +17,8 @@ language:
 locale: hi-IN
 hostname: hi.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -16,6 +16,9 @@ language:
   title: Hindi (IN)
 locale: hi-IN
 hostname: hi.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/ja.yml
+++ b/src/_data/sites/ja.yml
@@ -16,6 +16,9 @@ language:
   title: Japanese
 locale: ja-JP
 hostname: ja.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/ja.yml
+++ b/src/_data/sites/ja.yml
@@ -17,7 +17,8 @@ language:
 locale: ja-JP
 hostname: ja.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -17,7 +17,8 @@ language:
 locale: pt-BR
 hostname: pt-br.eslint.org
 locals:
-  docs: false
+  docs_latest: false
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -16,6 +16,9 @@ language:
   title: Portuguese (BR)
 locale: pt-BR
 hostname: pt-br.eslint.org
+locals:
+  docs: false
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/zh-hans.yml
+++ b/src/_data/sites/zh-hans.yml
@@ -16,6 +16,9 @@ language:
   title: Simplified Chinese
 locale: zh-hans
 hostname: zh-hans.eslint.org
+locals:
+  docs: zh-hans-docs.netlify.app
+  blog: false
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/_data/sites/zh-hans.yml
+++ b/src/_data/sites/zh-hans.yml
@@ -17,7 +17,8 @@ language:
 locale: zh-hans
 hostname: zh-hans.eslint.org
 locals:
-  docs: zh-hans-docs.netlify.app
+  docs_latest: zh-hans-docs.netlify.app
+  docs_head: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -18,7 +18,7 @@ eleventyExcludeFromCollections: true
 # Internal Redirects
 /demo/*                             /play/:splat 302!
 
-{% if site.locals.docs %}
+{% if site.locals.docs_latest %}
 
 # Old-Style Docs to New-Style Docs
 /docs/rules/*                       /docs/latest/rules/:splat 301!
@@ -27,13 +27,19 @@ eleventyExcludeFromCollections: true
 /docs/developer-guide/*             /docs/latest/developer-guide/:splat 301!
 
 # Regular Docs
-/docs/head/*                        https://{{ site.locals.docs }}/:splat 200!
-/docs/latest/*                      https://latest--{{ site.locals.docs }}/:splat 200!
-/docs/                             /docs/latest/ 301!
+/docs/latest/*                      https://{{ site.locals.docs_latest }}/:splat 200!
+/docs/                              /docs/latest/ 301!
 {% else %}
 
 # Redirect docs back to English site
 /docs/*                             https://eslint.org/docs/:splat 302!
+{% endif %}
+
+# Docs checked into main branch but not released
+{% if site.locals.docs_head %}
+/docs/head/*                        https://{{ site.locals.docs_head }}/:splat 200!
+{% else %}
+/docs/head/*                        https://eslint.org/docs/head/:splat 302!
 {% endif %}
 
 {% if site.locals.blog == false %}

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -18,7 +18,7 @@ eleventyExcludeFromCollections: true
 # Internal Redirects
 /demo/*                             /play/:splat 302!
 
-{% if site.language.code == "en" %}
+{% if site.locals.docs %}
 
 # Old-Style Docs to New-Style Docs
 /docs/rules/*                       /docs/latest/rules/:splat 301!
@@ -26,16 +26,17 @@ eleventyExcludeFromCollections: true
 /docs/maintainer-guide/*            /docs/latest/maintainer-guide/:splat 301!
 /docs/developer-guide/*             /docs/latest/developer-guide/:splat 301!
 
-# Version-Specific Docs
-/docs/head/*                        https://docs-eslint.netlify.app/:splat 200!
-/docs/latest/*                      https://latest--docs-eslint.netlify.app/:splat 200!
+# Regular Docs
+/docs/head/*                        https://{{ site.locals.docs }}/:splat 200!
+/docs/latest/*                      https://latest--{{ site.locals.docs }}/:splat 200!
 /docs/                             /docs/latest/ 301!
-
 {% else %}
 
-# Translated Sites Back to English Site
-/blog/*                             https://eslint.org/blog/:splat 302!
+# Redirect docs back to English site
 /docs/*                             https://eslint.org/docs/:splat 302!
-/demo/*                             https://eslint.org/play/:splat 302!
+{% endif %}
 
+{% if site.locals.blog == false %}
+# Redirect blog back to English site
+/blog/*                             https://eslint.org/blog/:splat 302!
 {% endif %}


### PR DESCRIPTION
This enables individual sites to refer to their own documentation sites. zh-hans is the first locale that has its own documentation site, so that is the only one that is enabled.