### PR TITLE
fix: open rule docs in new tab from the Popup component

### DIFF
--- a/src/playground/components/Popup.js
+++ b/src/playground/components/Popup.js
@@ -9,7 +9,9 @@ export default function Popup({ options, message, ruleName, onFix }) {
                 <div className="popup__main">
                     <p className="popup__text">{message}</p>
                     <div className="popup__refs">
-                        <a href={`https://eslint.org/docs/rules/${ruleName}`}>{ruleName}</a>
+                        <a href={`https://eslint.org/docs/rules/${ruleName}`} target="_blank" rel="noreferrer">
+                            {ruleName}
+                        </a>
                     </div>
                 </div>
 


### PR DESCRIPTION
Open docs in a new tab. Because as a user I want to look at the code in the editor and docs back and forth.

<img width="501" alt="Screenshot 2022-11-06 at 2 39 06 PM" src="https://user-images.githubusercontent.com/46647141/200162762-2bd9e731-504b-46c5-83c4-dba51e162f81.png">

Currently, this is also the behavior of links in the console.

<img width="1078" alt="Screenshot 2022-11-06 at 2 36 20 PM" src="https://user-images.githubusercontent.com/46647141/200162666-35e0bb80-603c-4829-a2bf-9ae8a4d609a4.png">
