### PR TITLE
fix: Redirect docs.eslint.org and cn.eslint.org

### DIFF
--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -20,6 +20,13 @@ locals:
   docs_latest: latest--docs-eslint.netlify.app
   docs_head: docs-eslint.netlify.app
   blog: true
+redirects:
+  - from: https://cn.eslint.org/*
+    to: https://zh-hans.eslint.org
+    status: 301!
+  - from: https://docs.eslint.org/*
+    to: https://eslint.org/docs/latest/
+    status: 302!
 
 #------------------------------------------------------------------------------
 # Analytics

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -7,6 +7,10 @@ eleventyExcludeFromCollections: true
 # Netlify Redirect Rules
 # https://www.netlify.com/docs/redirects/
 
+{% for redirect in site.redirects %}
+{{ redirect.from }}                 {{ redirect.to }} {{ redirect.status }}
+{% endfor %}
+
 # External Redirects
 /cla                                https://cla.js.foundation/eslint/eslint 302!
 /conduct                            https://code-of-conduct.openjsf.org/ 302!


### PR DESCRIPTION
This change ensures that docs.eslint.org and cn.eslint.org redirect to the correct place.

DNS is set up so that both docs.eslint.org and cn.eslint.org point to eslint.org. The intended outcome is that entering either of these two domain names will result in a redirect to the correct location.

docs.eslint.org should redirect to eslint.org/docs/latest/
cn.eslint.org should redirect to zh-hans.eslint.org

Fixes #368