### PR TITLE
fix: no-js bugs

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -146,6 +146,7 @@
     <script type="module" src="{{ '/assets/js/search.js' | url }}"></script>
     {%- endif -%}
     <link rel="stylesheet" type="text/css" href="{{ '/assets/css/styles.css' | url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/no-js.css' | url }}">
 </head>
 
 <body class="{{ hook | replace('_', '-') }}">

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -146,7 +146,6 @@
     <script type="module" src="{{ '/assets/js/search.js' | url }}"></script>
     {%- endif -%}
     <link rel="stylesheet" type="text/css" href="{{ '/assets/css/styles.css' | url }}">
-    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/no-js.css' | url }}">
 </head>
 
 <body class="{{ hook | replace('_', '-') }}">

--- a/src/assets/scss/no-js.scss
+++ b/src/assets/scss/no-js.scss
@@ -1,0 +1,25 @@
+@media (prefers-color-scheme: dark) {
+    pre[class*="language-"] {
+        color: var(--color-neutral-100);
+    }
+
+    .token.comment,
+    .token.prolog,
+    .token.doctype,
+    .token.cdata {
+        color: #8e9fae;
+    }
+
+    .logo-component {
+        fill: #fff;
+    }
+
+    #logo-center {
+        opacity: 0.6;
+    }
+
+    .donation-plan__github-logo {
+        -webkit-filter: invert(100%);
+        filter: invert(100%);
+    }
+}

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -40,3 +40,5 @@
 @import "components/popup";
 
 @import "utilities";
+
+@import "no-js";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
When javascript is disabled and the prefers-color-scheme is dark 
    1. code block texts are not visible.
    2. Logos /tag text not inverted based on the theme.

| Before  | After |
| ------------- | ------------- |
| ESLint Logo <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509204-f2908b65-c80e-4d0d-ac6c-7954b62c472c.png"> |  <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509219-fd33f437-2526-48bf-86ae-c8ab00905a8d.png"> |
| Code block text color <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509380-b2df21fc-b359-4d7d-bb73-0befc77421f6.png"> | <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509394-00f90634-8bf2-49b8-8c1f-6c38f6d4cdef.png"> |
| GitHub logo <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509438-6a259e3f-e810-404c-987d-278a787c81d1.png"> |  <img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/205509458-bec0e413-c742-4513-b965-62510e636694.png"> |





<!-- markdownlint-disable-file MD004 -->
