### PR TITLE
fix: show correct license in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "engines": {
         "node": "16.14.0"
     },
-    "license": "Apache",
+    "license": "Apache-2.0",
     "scripts": {
         "images": "imagemin '_site/assets/images' --out-dir='_site/assets/images'",
         "install:playground": "cd src/playground && npm install --no-package-lock",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "engines": {
         "node": "16.14.0"
     },
-    "license": "ISC",
+    "license": "Apache",
     "scripts": {
         "images": "imagemin '_site/assets/images' --out-dir='_site/assets/images'",
         "install:playground": "cd src/playground && npm install --no-package-lock",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Before the `license` filed in `package.json` is `ISC`, but `LICENSE` file is shown as Apache. So we should correct it.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
