### PR TITLE
Updated broken discord channel link with current one.

### DIFF
--- a/src/content/blog/2022-08-08-new-config-system-part-3.md
+++ b/src/content/blog/2022-08-08-new-config-system-part-3.md
@@ -141,6 +141,6 @@ Some things to keep in mind when using `FlatRuleTester`:
 
 We think that the new config system will be a great experience for ESLint users, but in order for that to happen, we have to make sure that the ESLint ecosystem is ready for these changes. That's why we've put together this developer preview to let all of our plugin, custom rule, parser, and shareable config authors get an early look at how their packages will work in the new config system. This is your opportunity to give us your feedback and help work through any incompatibilities or problems with flat config.
 
-Please try out flat config with your packages and let us know how it goes by [starting a discussion](https://github.com/eslint/eslint/discussions/new) or stopping by the [Discord #developers channel](https://eslint.org/chat/developers) if you have questions or [opening an issue](https://github.com/eslint/eslint/issues/new) if you discover a problem.
+Please try out flat config with your packages and let us know how it goes by [starting a discussion](https://github.com/eslint/eslint/discussions/new) or stopping by the [Discord #developers channel](https://eslint.org/chat) if you have questions or [opening an issue](https://github.com/eslint/eslint/issues/new) if you discover a problem.
 
 We appreciate your help and feedback!


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
To update the broken discord link with the current working link in the blog post.

![Screenshot 2022-12-16 at 12 10 11 AM](https://user-images.githubusercontent.com/26796157/207942007-01adb61e-4c8c-4ae9-b610-ad251a3580ff.png)

#### What changes did you make? (Give an overview)
changed the discord url  from https://eslint.org/chat/developers to https://eslint.org/chat

