### PR TITLE
fix: footer social icons layout with nowrap

### DIFF
--- a/src/assets/scss/components/language-switcher.scss
+++ b/src/assets/scss/components/language-switcher.scss
@@ -13,8 +13,8 @@
 }
 
 .switcher--language .switcher__select {
-    min-width: 14rem;
-    flex: 0 1 14rem;
+    min-width: 15rem;
+    flex: 0 1 15rem;
 }
 
 .language-switcher {

--- a/src/assets/scss/components/language-switcher.scss
+++ b/src/assets/scss/components/language-switcher.scss
@@ -13,8 +13,8 @@
 }
 
 .switcher--language .switcher__select {
-    min-width: 15rem;
-    flex: 1 0 15rem;
+    min-width: 14rem;
+    flex: 0 1 14rem;
 }
 
 .language-switcher {

--- a/src/assets/scss/components/social-icons.scss
+++ b/src/assets/scss/components/social-icons.scss
@@ -1,16 +1,9 @@
 .eslint-social-icons {
-
-    @media all and (max-width: 1023px) {
-        margin-bottom: -1rem;
-        margin-block-end: -1rem;
-    }
-
     ul {
         margin: 0;
         padding: 0;
-        margin-left: -1rem;
-        margin-inline-start: -1rem;
-        display: inline-flex;
+        display: flex;
+        gap: 1.5rem;
 
         li {
             margin: 0;
@@ -19,7 +12,6 @@
 
             a {
                 display: flex;
-                padding: 1rem;
             }
         }
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
Fixed footer socials icon with nowrap

#### What changes did you make? (Give an overview)

<details>
<summary>Homepage</summary>

![image](https://user-images.githubusercontent.com/42532987/208135449-cb638e6f-4f15-4dc1-a20c-1325d13a94f0.png)
![image](https://user-images.githubusercontent.com/42532987/208135505-ca8b88bc-7585-43bc-b82f-419f248b3751.png)
</details>

<details>
<summary>Playground</summary>

![image](https://user-images.githubusercontent.com/42532987/208135884-a294dc5f-f15c-4e10-9436-adf20bc5c89d.png)
![image](https://user-images.githubusercontent.com/42532987/208135771-2d229ffc-4901-4d8f-864f-637930826759.png)
</details>


#### Related Issues 

Ref https://github.com/eslint/eslint.org/pull/381#issuecomment-1349514328

<!-- markdownlint-disable-file MD004 -->
