### PR TITLE
fix: use sponsor's GitHub username when name is missing

### DIFF
--- a/src/_data/donations.json
+++ b/src/_data/donations.json
@@ -252,15 +252,6 @@
         "source": "opencollective"
     },
     {
-        "id": "SA_kwHOAFvahM4ABIzq",
-        "name": null,
-        "image": "https://avatars.githubusercontent.com/u/23113912?u=8f0f72610d5ec4a8bd382680e693984210b1cf18&v=4",
-        "url": "https://github.com/ndNovaDev",
-        "amount": 10,
-        "date": "2022-12-24T02:22:57Z",
-        "source": "github"
-    },
-    {
         "id": "SA_kwHOAFvahM4ABHcn",
         "name": "Gabriel Gregório",
         "image": "https://avatars.githubusercontent.com/u/48621655?u=8d11d15f533053597c354e57e0ed0fbb453c175b&v=4",

--- a/src/_data/sponsors.json
+++ b/src/_data/sponsors.json
@@ -453,14 +453,6 @@
             "tier": "backer"
         },
         {
-            "name": null,
-            "image": "https://avatars.githubusercontent.com/u/23113912?u=8f0f72610d5ec4a8bd382680e693984210b1cf18&v=4",
-            "url": "https://github.com/ndNovaDev",
-            "monthlyDonation": 10,
-            "source": "github",
-            "tier": "backer"
-        },
-        {
             "name": "Raimonds Korzenevskis",
             "image": "https://avatars.githubusercontent.com/u/28185559?u=4e564dd0947ebc75d9fe02a90b7149256a48164e&v=4",
             "url": "raykay.dk",
@@ -1229,14 +1221,6 @@
             "tier": "backer"
         },
         {
-            "name": null,
-            "image": "https://avatars.githubusercontent.com/u/8572152?v=4",
-            "url": "https://github.com/per1234",
-            "monthlyDonation": 5,
-            "source": "github",
-            "tier": "backer"
-        },
-        {
             "name": "Gabi",
             "image": "https://avatars.githubusercontent.com/u/9082013?u=0a2400198d68bd7155832384f6135c22aefa6f4b&v=4",
             "url": "https://github.com/0xGabi",
@@ -1320,14 +1304,6 @@
             "name": "None",
             "image": "https://avatars.githubusercontent.com/u/17837186?v=4",
             "url": "https://github.com/shadmau",
-            "monthlyDonation": 5,
-            "source": "github",
-            "tier": "backer"
-        },
-        {
-            "name": null,
-            "image": "https://avatars.githubusercontent.com/u/19206886?u=5302740136db6d2fe4d4009680064ce95a1896fc&v=4",
-            "url": "https://github.com/portfine",
             "monthlyDonation": 5,
             "source": "github",
             "tier": "backer"

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -157,7 +157,7 @@ hook: "sponsors_page"
             {% for donation in donations | limitTo(50) %}
             <li class="donations-item">
                 {% set donation_image = donation.image %}
-                {% set donation_name = donation.name %}
+                {% set donation_name = donation.name or '' %}
                 {% set donation_amount = donation.amount | dollars %}
                 {% set donation_date = donation.date | readableDateFromISO %}
 

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -157,7 +157,7 @@ hook: "sponsors_page"
             {% for donation in donations | limitTo(50) %}
             <li class="donations-item">
                 {% set donation_image = donation.image %}
-                {% set donation_name = donation.name or '' %}
+                {% set donation_name = donation.name %}
                 {% set donation_amount = donation.amount | dollars %}
                 {% set donation_date = donation.date | readableDateFromISO %}
 

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -239,7 +239,7 @@ async function fetchGitHubSponsors() {
         .filter(transaction => transaction.tier && transaction.tier.isOneTime)
         .map(({ sponsor, timestamp, tier, id }) => ({
             id,
-            name: sponsor.name,
+            name: sponsor.name || sponsor.login,
             image: sponsor.avatarUrl,
             url: sponsor.websiteUrl || sponsor.url,
             amount: tier.monthlyPriceInDollars,

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -227,7 +227,7 @@ async function fetchGitHubSponsors() {
     // return an array in the same format as Open Collective
     const sponsors = organization.sponsorshipsAsMaintainer.nodes
         .map(({ sponsor, tier }) => ({
-            name: sponsor.name,
+            name: sponsor.name || sponsor.login,
             image: sponsor.avatarUrl,
             url: sponsor.websiteUrl || sponsor.url,
             monthlyDonation: tier.monthlyPriceInDollars,
@@ -249,7 +249,7 @@ async function fetchGitHubSponsors() {
         .filter(donation => {
             // invoiced recurring donations are incorrectly marked as one-time
             const sponsor = sponsors.find(sponsor => sponsor.name === donation.name);
-            
+
             // only include if the amount is different than the monthly amount
             return sponsor ? sponsor.monthlyDonation !== donation.amount : true;
         });
@@ -273,11 +273,11 @@ async function fetchGitHubSponsors() {
         {
             sponsors: openCollectiveSponsors,
             donations: openCollectiveDonations
-        }, 
+        },
         {
             sponsors: githubSponsors,
             donations: githubDonations
-        }, 
+        },
     ] = await Promise.all([
         fetchOpenCollectiveData(),
         fetchGitHubSponsors()


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

The CI [has failed](https://github.com/eslint/eslint.org/actions/runs/3770301500/jobs/6410053617) because of a `null` value of name coming from here https://github.com/eslint/eslint.org/commit/415e0bba84b8d205faa5c47924c928b0b0074dba#diff-ff108750031135fb05819cca15c41069cf217df9c9e21745012a5af2e965c55bR256.

And I can confirm it's not a glitch or something because the Web version of GitHub GraphQL API did return `null` for this sponsor:

![CleanShot 2022-12-24 at 19 38 49@2x](https://user-images.githubusercontent.com/1091472/209434335-469ceb44-14b9-4eb2-8b7a-9415694526b8.png)


<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Set a fallback value for `name` in template.

    Currently I'm setting it to `''`, but I'm not sure it's a good option as it could mess the layout:

    ![](https://user-images.githubusercontent.com/1091472/209434827-2d700eb9-9884-45de-9519-171ff7bdadf8.png)

    But it shouldn't be a problem once the data fetching is done next midnight because there's another fallback value in `fetch-sponsors.js`, see next.

2. Set the value of `name` to `login` when `null` in `fetch-sponsors.js`



#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
