### PR TITLE
fix: different size of animation image

### DIFF
--- a/src/assets/js/animation.js
+++ b/src/assets/js/animation.js
@@ -152,4 +152,19 @@
       },
       '+=0.25'
     );
+
+    document.addEventListener("DOMContentLoaded", function () {
+      const dropImg = document.querySelectorAll('.anim__dropdown-img');
+      const winWidth = window.innerWidth;
+
+      dropImg.forEach(function (img) {
+        var rect = img.getBoundingClientRect();
+
+        if(winWidth < rect.right) {
+          img.style.float = 'right';
+        } else {
+          img.style.float = 'none';
+        }
+      });
+    });
 })();

--- a/src/assets/scss/animation.scss
+++ b/src/assets/scss/animation.scss
@@ -67,6 +67,16 @@
     &__dropdown-img {
         position: relative;
         box-shadow: var(--shadow-lg);
+        max-width: 330px;
+        margin: 0 auto;
+
+        @media only screen and (max-width: 800px) {
+            max-width: 230px;
+        }
+
+        @media only screen and (max-width: 600px) {
+            max-width: 200px;
+        }
     }
 
     @media only screen and (min-width: 405px) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
The animation image of home page is having different sizes on different languages as it is varying with the text 'Problem', because of this in some languages it's width is very large and some one has a small one.
<details>
<summary>in chinese</summary>

![Screenshot 2023-01-30 131652](https://user-images.githubusercontent.com/86398394/218319218-c3389f8f-d338-4399-8f71-17378807c39b.png)
</details>

<details>
<summary>in french</summary>

![Screenshot 2023-01-30 131903](https://user-images.githubusercontent.com/86398394/218319286-695b75e8-3358-4d37-8b36-05fbdd4e504f.png)
</details>
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
added the `max-width` property to the image for different screen size and since with the steady width image can overflow so added the `float: right` through JavaScript on overflowing.
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
