### PR TITLE
fix: add reference to zh-hans docs sitemap

### DIFF
--- a/src/static/sitemap-index.njk
+++ b/src/static/sitemap-index.njk
@@ -7,7 +7,7 @@ eleventyExcludeFromCollections: true
     <sitemap>
         <loc>{{ ["https://", site.hostname, "/sitemap.xml"] | join }}</loc>
     </sitemap>
-    {% if site.language.code == "en" %}
+    {% if site.locals.docs_latest %}
     <sitemap>
         <loc>{{ ["https://", site.hostname, "/docs/latest/sitemap.xml"] | join }}</loc>
     </sitemap>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

In https://zh-hans.eslint.org/sitemap-index.xml, adds a reference to https://zh-hans.eslint.org/docs/latest/sitemap.xml.

Before the change:

```xml
<?xml version="1.0" encoding="utf-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
        <loc>https://zh-hans.eslint.org/sitemap.xml</loc>
    </sitemap>
    
</sitemapindex>
```

After the change:

```xml
<?xml version="1.0" encoding="utf-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
        <loc>https://zh-hans.eslint.org/sitemap.xml</loc>
    </sitemap>
    
    <sitemap>
        <loc>https://zh-hans.eslint.org/docs/latest/sitemap.xml</loc>
    </sitemap>
    
</sitemapindex>

```

#### What changes did you make? (Give an overview)

In the sitemap index template, I replaced a condition `if site.language.code == "en"` with `if site.locals.docs_latest`. This will generate a docs sitemap reference for all sites that have translated docs.

#### Related Issues

No.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
