### PR TITLE
fix: enable docs IA update redirects for zh-hans site

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -32,8 +32,6 @@ eleventyExcludeFromCollections: true
 /docs/maintainer-guide/*            /docs/latest/maintainer-guide/:splat 301!
 /docs/developer-guide/*             /docs/latest/developer-guide/:splat 301!
 
-{% if site.language.code == "en" %}
-
 # Redirects for the ESLint IA Refactor (https://github.com/eslint/rfcs/pull/97)
 /docs/latest/user-guide/                                     /docs/latest/use/ 301!
 /docs/latest/user-guide/core-concepts                        /docs/latest/use/core-concepts 301!
@@ -49,8 +47,18 @@ eleventyExcludeFromCollections: true
 /docs/latest/user-guide/integrations                         /docs/latest/use/integrations 301!
 /docs/latest/user-guide/migrating-to-8.0.0                   /docs/latest/use/migrate-to-8.0.0 301!
 /docs/latest/developer-guide/architecture/                   /docs/latest/contribute/architecture/ 301!
+
+{% if site.language.code == "en" %}
+
 /docs/latest/developer-guide/source-code                     /docs/latest/contribute/development-environment 301!
 /docs/latest/contribute/source-code                          /docs/latest/contribute/development-environment 301!
+
+{% else %}
+
+/docs/latest/developer-guide/source-code                     /docs/latest/contribute/source-code 301!
+
+{% endif %}
+
 /docs/latest/developer-guide/development-environment         /docs/latest/contribute/development-environment 301!
 /docs/latest/developer-guide/unit-tests                      /docs/latest/contribute/tests 301!
 /docs/latest/developer-guide/working-with-rules              /docs/latest/extend/custom-rules 301!
@@ -82,8 +90,6 @@ eleventyExcludeFromCollections: true
 /docs/latest/user-guide/*                                    /docs/latest/use/:splat 301!
 /docs/latest/developer-guide/*                               /docs/latest/extend/:splat 301!
 /docs/latest/maintainer-guide/*                              /docs/latest/maintain/:splat 301!
-
-{% endif %}
 
 # Regular Docs
 /docs/latest/*                      https://{{ site.locals.docs_latest }}/:splat 200!


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

After merging https://github.com/eslint/zh-hans.docs.eslint.org/pull/95, which included URL changes from https://github.com/eslint/eslint/pull/16665, we forgot to enable redirects (https://github.com/eslint/eslint.org/pull/388) for the zh-hans site.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated redirects template to enable docs IA update redirects for the zh-hans site.

Redirects from `source-code` to `development-environment` (https://github.com/eslint/eslint.org/pull/409) are still specific for the en site only because the change (https://github.com/eslint/eslint/pull/16780) was merged for v8.33.0, while the zh-hans docs site is currently synced with 8.32.0. 

#### Related Issues

No.

#### Is there anything you'd like reviewers to focus on?

Please double check how this change affects the `_site/_redirects` file:

* For the zh-hans site, it should have 46 new redirect rules, the same as in https://github.com/eslint/eslint.org/pull/388.
* For all other languages, there should be no diff except for a few added or removed blank lines.

<!-- markdownlint-disable-file MD004 -->
