### PR TITLE
fix: language switcher on non-translated pages should open the homepage

### DIFF
--- a/src/_includes/components/language-switcher.html
+++ b/src/_includes/components/language-switcher.html
@@ -14,7 +14,7 @@
             {% for key, other_site in sites %}
             <option value="{{ other_site.language.code }}"
                     title="{{ other_site.language.title }}" 
-                    data-url="https://{{ other_site.hostname }}{{ page.url }}"
+                    data-url="https://{{ other_site.hostname }}{% if multilingual %}{{ page.url }}{% endif %}"
                     {% if site.language.code == other_site.language.code %} selected {% endif %}>
                 {{ other_site.language.flag }} {{ other_site.language.name }}
             </option>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Currently, when you're on a page that isn't translated to other languages, selecting a different language ends up redirecting you to the same page, which looks confusing. For example, [open a blog post](https://eslint.org/blog/2023/04/eslint-v8.39.0-released/) and select a different language in the language switcher at the bottom of the page.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the language switcher component to redirect to the homepage of the selected language if the current page doesn't have translations (`multilingual: true` in the frontmatter; [example](https://github.com/eslint/eslint.org/blob/2f53fc833381f5c7a505aea8a893530c000c281b/src/content/pages/team.html#L4)).

#### Related Issues

No.

#### Is there anything you'd like reviewers to focus on?

Does this make more sense than the current behavior?

<!-- markdownlint-disable-file MD004 -->
