### PR TITLE
perf: memoize the extensions in code editor to reduce expensive calculations

### DIFF
--- a/src/playground/components/CodeEditor.js
+++ b/src/playground/components/CodeEditor.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { history } from "@codemirror/history";
 import { bracketMatching } from "@codemirror/matchbrackets";
@@ -9,20 +9,22 @@ import { Linter as ESLint } from "../node_modules/eslint/lib/linter/";
 import "../scss/editor.scss";
 
 export default function CodeEditor({ codeValue, onUpdate, eslintOptions }) {
+    const extensions = useMemo(() => [
+        history(),
+        bracketMatching(),
+        linter(esLint(new ESLint(), eslintOptions), { delay: 0 }),
+        javascript(),
+        ESLintPlaygroundTheme,
+        ESLintPlaygroundHighlightStyle
+    ], [eslintOptions]);
+
     return (
         <CodeMirror
             value={codeValue}
             minWidth="100%"
             height="100%"
             extensions={
-                [
-                    history(),
-                    bracketMatching(),
-                    linter(esLint(new ESLint(), eslintOptions), { delay: 0 }),
-                    javascript(),
-                    ESLintPlaygroundTheme,
-                    ESLintPlaygroundHighlightStyle
-                ]
+                extensions
             }
             onChange={value => {
                 onUpdate(value);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

Memoize the extensions in code editor to reduce expensive calculations on every re-render

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Used `useMemo` to wrap the extensions array to keep the reference.

#### Is there anything you'd like reviewers to focus on?

![image](https://github.com/eslint/eslint.org/assets/42532987/c23a1801-dfd5-4ea3-b5ea-293564b655c9)

Ref: https://www.npmjs.com/package/@uiw/react-codemirror?activeTab=readme

<!-- markdownlint-disable-file MD004 -->
