### PR TITLE
docs: redirect getting source code to development environment on zh-hans

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -47,18 +47,8 @@ eleventyExcludeFromCollections: true
 /docs/latest/user-guide/integrations                         /docs/latest/use/integrations 301!
 /docs/latest/user-guide/migrating-to-8.0.0                   /docs/latest/use/migrate-to-8.0.0 301!
 /docs/latest/developer-guide/architecture/                   /docs/latest/contribute/architecture/ 301!
-
-{% if site.language.code == "en" %}
-
 /docs/latest/developer-guide/source-code                     /docs/latest/contribute/development-environment 301!
 /docs/latest/contribute/source-code                          /docs/latest/contribute/development-environment 301!
-
-{% else %}
-
-/docs/latest/developer-guide/source-code                     /docs/latest/contribute/source-code 301!
-
-{% endif %}
-
 /docs/latest/developer-guide/development-environment         /docs/latest/contribute/development-environment 301!
 /docs/latest/developer-guide/unit-tests                      /docs/latest/contribute/tests 301!
 /docs/latest/developer-guide/working-with-rules              /docs/latest/extend/custom-rules 301!


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Redirects https://zh-hans.eslint.org/docs/latest/contribute/source-code to https://zh-hans.eslint.org/docs/latest/contribute/development-environment

#### What changes did you make? (Give an overview)

Updated the redirects file to remove a `site.language.code == "en"` conditional that will be no longer valid after syncing zh-hans docs site with v8.33.0.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

Should be merged after merging https://github.com/eslint/zh-hans.docs.eslint.org/pull/99

<!-- markdownlint-disable-file MD004 -->
