### PR TITLE
docs: Remove plugin parsers

### DIFF
--- a/src/content/blog/2022-08-05-new-config-system-part-2.md
+++ b/src/content/blog/2022-08-05-new-config-system-part-2.md
@@ -352,40 +352,6 @@ Here, a custom rule is imported as `myrule` and then a runtime plugin is created
 
 As a result, we will be removing `--rulesdir` once the transition to flat config is complete.
 
-### Custom parsers in plugins
-
-One of the weird artifacts of ESLint's development is that parsers were never part of plugins. That's because custom parsers existed long before plugins did, and we never went back to make the two work well together. In flat config, we took the opportunity to fix this problem by allowing plugins to expose parsers in the same that they expose processors and rules. For example, you can now define a plugin that looks like this:
-
-```js
-export default {
-    parsers: {
-        parserName: {
-            parse() { /*... */ }
-        }
-    }
-}
-```
-
-This plugin exposes a parser called `parserName` under the `parsers` key. You can then use this parser in your config like this:
-
-```js
-import custom from "./custom-plugin.js";
-
-export default [
-    {
-        files: ["**/*.js"],
-        plugins: {
-            custom
-        },
-        languageOptions: {
-            parser: "custom/parserName"
-        }
-    }
-];
-```
-
-This config creates a plugin namespace called `custom`. The custom parser can then be accessed using the string `"custom/parserName"`.
-
 ### Processors works in a similar way to eslintrc
 
 The `processor` top-level key works mostly the same as in eslintrc, with the primary use case being to use a processor that is defined in a plugin, for example:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

We ended up removing the ability to have parsers in plugins as part of the language plugins work, so updating the blog post to avoid confusion.

#### Related Issues

https://github.com/eslint/eslint/issues/16930

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
