### PR TITLE
fix: Use a unique key for each message

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -111,6 +111,7 @@ const App = () => {
     }, [options, text]);
 
     const { messages, output, fatalMessage, error: crashError, validationError } = lint();
+    const lintTime = Date.now();
     const isInvalidAutofix = fatalMessage && text !== output;
 
     const onFix = message => {
@@ -209,23 +210,14 @@ const App = () => {
                         {
                             validationError && <Alert type="error" text={validationError.message} />
                         }
-                        {messages.length > 0 && messages.map(message => (
-                            message.suggestions ? (
-                                <Alert
-                                    key={`${message.ruleId}-${message.line}-${message.column}`}
-                                    type={message.severity === 2 ? "error" : "warning"}
-                                    message={message}
-                                    suggestions={message.suggestions}
-                                    onFix={onFix}
-                                />
-                            ) : (
-                                <Alert
-                                    key={`${message.ruleId}-${message.line}-${message.column}`}
-                                    type={message.severity === 2 ? "error" : "warning"}
-                                    message={message}
-                                    onFix={onFix}
-                                />
-                            )
+                        {messages.length > 0 && messages.map((message, index) => (
+                            <Alert
+                                key={`${lintTime}-${index}`}
+                                type={message.severity === 2 ? "error" : "warning"}
+                                message={message}
+                                suggestions={message.suggestions}
+                                onFix={onFix}
+                            />
                         ))}
                     </section>
                 </Split>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

This fixes a rendering issue in the playground that would occur when a rule produces multiple messages with the same `line` and `column` as described in #445.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes the key calculation for messages in the playground to ensure that each key is unique.

React requires all elements in a list to have a unique key, but the messages reported by ESLint are not necessarily distinct, thus we cannot rely on message properties only to create a unique key.

Instead of a combination of `ruleId`, `column` and `line`, I'm using the message index and the timestamp of the last lint as a key.

#### Related Issues

Fixes #445

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
