### PR TITLE
feat: allow partial configs in playground URL

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -21,6 +21,28 @@ const rulesMeta = Array.from(rules.entries()).reduce((result, [key, value]) => {
     return result;
 }, {});
 
+const fillOptionsDefaults = (options = {}) => ({
+    ...options,
+    env: {
+        es6: true,
+        ...options.env
+    },
+    parserOptions: {
+        ...options.parserOptions,
+        ecmaFeatures: {
+            ecmaVersion: "latest",
+            sourceType: "script",
+            ...options.ecmaFeatures
+        }
+    },
+    rules: options.rules ?? [...rules.entries()].reduce((result, [ruleId, rule]) => {
+        if (rule.meta.docs.recommended) {
+            result[ruleId] = ["error"];
+        }
+        return result;
+    }, {})
+});
+
 const getUrlState = () => {
     try {
         return JSON.parse(Unicode.decodeFromBase64(window.location.hash.replace(/^#/u, "")));
@@ -44,24 +66,7 @@ const App = () => {
     const { text: urlText, options: urlOptions } = getUrlState();
     const [text, setText] = useState(urlText || storedText || "/* eslint quotes: [\"error\", \"double\"] */\nconst a = 'b';");
     const [fix, setFix] = useState(false);
-    const [options, setOptions] = useState(
-        urlOptions || storedOptions || {
-            parserOptions: {
-                ecmaVersion: "latest",
-                sourceType: "script",
-                ecmaFeatures: {}
-            },
-            rules: [...rules.entries()].reduce((result, [ruleId, rule]) => {
-                if (rule.meta.docs.recommended) {
-                    result[ruleId] = ["error"];
-                }
-                return result;
-            }, {}),
-            env: {
-                es6: true
-            }
-        }
-    );
+    const [options, setOptions] = useState(fillOptionsDefaults(urlOptions || storedOptions));
 
     const lint = () => {
         try {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -21,27 +21,33 @@ const rulesMeta = Array.from(rules.entries()).reduce((result, [key, value]) => {
     return result;
 }, {});
 
-const fillOptionsDefaults = (options = {}) => ({
-    ...options,
-    env: {
-        es6: true,
-        ...options.env
-    },
-    parserOptions: {
-        ...options.parserOptions,
-        ecmaFeatures: {
-            ecmaVersion: "latest",
-            sourceType: "script",
-            ...options.ecmaFeatures
+const defaultParserOptions = {
+    ecmaFeatures: {},
+    ecmaVersion: "latest",
+    sourceType: "script"
+};
+
+const fillOptionsDefaults = options =>
+    (options
+        ? {
+            env: {},
+            rules: {},
+            ...options,
+            parserOptions: {
+                ...defaultParserOptions,
+                ...options.parserOptions
+            }
         }
-    },
-    rules: options.rules ?? [...rules.entries()].reduce((result, [ruleId, rule]) => {
-        if (rule.meta.docs.recommended) {
-            result[ruleId] = ["error"];
-        }
-        return result;
-    }, {})
-});
+        : {
+            env: { es6: true },
+            parserOptions: defaultParserOptions,
+            rules: [...rules.entries()].reduce((result, [ruleId, rule]) => {
+                if (rule.meta.docs.recommended) {
+                    result[ruleId] = ["error"];
+                }
+                return result;
+            }, {})
+        });
 
 const getUrlState = () => {
     try {

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -184,7 +184,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                         <Select
                             isClearable
                             isMulti
-                            defaultValue={ECMAFeaturesOptions.filter(ecmaFeatureName => options.parserOptions.ecmaFeatures[ecmaFeatureName.value])}
+                            defaultValue={ECMAFeaturesOptions.filter(ecmaFeatureName => options.parserOptions.ecmaFeatures?.[ecmaFeatureName.value])}
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -184,7 +184,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                         <Select
                             isClearable
                             isMulti
-                            defaultValue={ECMAFeaturesOptions.filter(ecmaFeatureName => options.parserOptions.ecmaFeatures?.[ecmaFeatureName.value])}
+                            defaultValue={ECMAFeaturesOptions.filter(ecmaFeatureName => options.parserOptions.ecmaFeatures[ecmaFeatureName.value])}
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Fixes a crash on the playground when `parserOptions` is provided as an object without `ecmaFeatures`.

#### What changes did you make? (Give an overview)

Added a `?.` for attempted lookups of `parserOptions.ecmaFeatures` members.

#### Related Issues

Fixes #450

#### Is there anything you'd like reviewers to focus on?

Nothing comes to mind 🙂 
