### PR TITLE
fix: use empty options in the Playground when URL contains only text

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -72,7 +72,7 @@ const App = () => {
     const { text: urlText, options: urlOptions } = getUrlState();
     const [text, setText] = useState(urlText || storedText || "/* eslint quotes: [\"error\", \"double\"] */\nconst a = 'b';");
     const [fix, setFix] = useState(false);
-    const [options, setOptions] = useState(fillOptionsDefaults(urlOptions || storedOptions));
+    const [options, setOptions] = useState(fillOptionsDefaults(urlText ? urlOptions || {} : storedOptions));
 
     const lint = () => {
         try {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

When the docs site passes only `text`, Playground currently sets stored or default `options`.

Here's an example, this link is on the first example of `array-callback-return`:

https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyYXktY2FsbGJhY2stcmV0dXJuOiBcImVycm9yXCIqL1xuXG52YXIgaW5kZXhNYXAgPSBteUFycmF5LnJlZHVjZShmdW5jdGlvbihtZW1vLCBpdGVtLCBpbmRleCkge1xuICAgIG1lbW9baXRlbV0gPSBpbmRleDtcbn0sIHt9KTtcblxudmFyIGZvbyA9IEFycmF5LmZyb20obm9kZXMsIGZ1bmN0aW9uKG5vZGUpIHtcbiAgICBpZiAobm9kZS50YWdOYW1lID09PSBcIkRJVlwiKSB7XG4gICAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbn0pO1xuXG52YXIgYmFyID0gZm9vLmZpbHRlcihmdW5jdGlvbih4KSB7XG4gICAgaWYgKHgpIHtcbiAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgfSBlbHNlIHtcbiAgICAgICAgcmV0dXJuO1xuICAgIH1cbn0pO1xuIn0=

This is not desirable, options should be empty.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated Playground to set empty options in the mentioned case.

Test link:

https://deploy-preview-453--new-eslint.netlify.app/play/#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyYXktY2FsbGJhY2stcmV0dXJuOiBcImVycm9yXCIqL1xuXG52YXIgaW5kZXhNYXAgPSBteUFycmF5LnJlZHVjZShmdW5jdGlvbihtZW1vLCBpdGVtLCBpbmRleCkge1xuICAgIG1lbW9baXRlbV0gPSBpbmRleDtcbn0sIHt9KTtcblxudmFyIGZvbyA9IEFycmF5LmZyb20obm9kZXMsIGZ1bmN0aW9uKG5vZGUpIHtcbiAgICBpZiAobm9kZS50YWdOYW1lID09PSBcIkRJVlwiKSB7XG4gICAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbn0pO1xuXG52YXIgYmFyID0gZm9vLmZpbHRlcihmdW5jdGlvbih4KSB7XG4gICAgaWYgKHgpIHtcbiAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgfSBlbHNlIHtcbiAgICAgICAgcmV0dXJuO1xuICAgIH1cbn0pO1xuIn0=

#### Related Issues

No.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
