### PR TITLE
fix: Exclude private sponsors from list

### DIFF
--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -168,7 +168,7 @@ async function fetchGitHubSponsors() {
 
     const { organization } = await githubGraphQL(`query {
         organization(login: "eslint") {
-          sponsorshipsAsMaintainer (first: 100) {
+          sponsorshipsAsMaintainer (first: 100, includePrivate: false) {
             nodes {
               sponsor: sponsorEntity {
                 ...on User {

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -191,7 +191,7 @@ async function fetchGitHubSponsors() {
               }
             }
           }
-          sponsorsActivities (first: 100) {
+          sponsorsActivities (first: 100, includePrivate: false) {
             nodes {
               id
               sponsor {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

A few months ago we noticed that private sponsorships were being shown on the website. At the time, GitHub didn't have a way to filter out private sponsorships and also didn't provide any way to tell if a sponsorship was private, so we couldn't do anything about it.

I just received word that they have added in the ability to filter out private sponsorships and so I updated `fetch-sponsors.js` to do that.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
