### PR TITLE
fix: OC sponsors fetch for cancelled orders

### DIFF
--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -75,7 +75,7 @@ async function fetchOpenCollectiveData() {
 
     const endpoint = "https://api.opencollective.com/graphql/v2";
     const now = new Date();
-    const startOfCurrentMonth = `${now.getFullYear()}-${now.getMonth().toString().padStart(2, "0")}-01T00:00:00Z`;
+    const startOfCurrentMonth = `${now.getFullYear()}-${(now.getMonth()+1).toString().padStart(2, "0")}-01T00:00:00Z`;
 
     /*
      * account.orders - These are the currently active sponsorships.
@@ -107,7 +107,7 @@ async function fetchOpenCollectiveData() {
             }
           }
   
-          cancelledOrders: orders(filter: INCOMING, onlySubscriptions: true, dateFrom:"${startOfCurrentMonth}") {
+          cancelledOrders: orders(status: CANCELLED, filter: INCOMING, onlySubscriptions: true, dateFrom:"${startOfCurrentMonth}") {
             totalCount
             nodes {
               fromAccount {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Ensure that we are retrieving only cancelled sponsorships within the next month rather than all sponsorships that aren't active. Also updated the month timestamp logic to account for zero-based months.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
