### PR TITLE
fix: typo in 2023-07-28-eslint-v8.46.0-released.md

### DIFF
--- a/src/content/blog/2023-07-28-eslint-v8.46.0-released.md
+++ b/src/content/blog/2023-07-28-eslint-v8.46.0-released.md
@@ -16,7 +16,7 @@ tags:
 
 ### Support for regular expressions `v` flag
 
-We have updated ESLint to fully support the ECMAScript 2023 [regular expression `v` flag](https://github.com/tc39/proposal-regexp-v-flag). This flag allows more complex operations such as difference/subtraction, intersection, and nested character classes. These updates include parsing and ensuring that rules related to regular expressions are behaving as expected.
+We have updated ESLint to fully support the ECMAScript 2024 [regular expression `v` flag](https://github.com/tc39/proposal-regexp-v-flag). This flag allows more complex operations such as difference/subtraction, intersection, and nested character classes. These updates include parsing and ensuring that rules related to regular expressions are behaving as expected.
 
 ### Better error messages for flat config
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The v flag is in ES2024, not ES2023, so I fixed that.
https://github.com/tc39/proposals/blob/main/finished-proposals.md

#### Related Issues

None

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
