### PR TITLE
fix: fix styling on home page

### DIFF
--- a/src/assets/scss/homepage.scss
+++ b/src/assets/scss/homepage.scss
@@ -144,6 +144,7 @@
 
     @media all and (min-width: 768px) {
         display: flex;
+        justify-content: space-evenly;
     }
 }
 


### PR DESCRIPTION
Section styled with metrics class on home page not aligned correctly on big screens more that 2600px width

fix/metrics-align-correctly-at-big-screens

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
- it's fixes style of a section on home page the problem shows only at extra-large screens >2600px
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- add ```
 justify-content: space-evenly;``` 
at homepage.scss
- before : 
![image1](https://github.com/eslint/eslint.org/assets/78050205/abbcd44f-0abd-454b-aeb2-27cd597a2b82)
- after :
![image2](https://github.com/eslint/eslint.org/assets/78050205/bda34cad-550c-44cf-97f1-1c8c88815444)

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
