### PR TITLE
ci: use Node 18 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: "18.x"
           cache: "npm"
       - name: Install website dependencies
         run: npm ci

--- a/.github/workflows/data-fetch.yml
+++ b/.github/workflows/data-fetch.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: "lts/*"
+        node-version: "18.x"
 
     - name: Install npm packages
       run: npm install
@@ -40,7 +40,7 @@ jobs:
       run: |
         git config user.name "GitHub Actions Bot"
         git config user.email "<eslint@googlegroups.com>"
-    
+
     - name: Save updated files
       run: |
         chmod +x ./tools/commit-data.sh


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

To fix our CI and data fetch workflows. As of today, `node-version: "lts/*"` resolves to Node 20, and `npm install`/`npm ci` currently doesn't work on Node 20. The problem is reported in https://github.com/uhop/node-re2/issues/192.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `ci.yml` and `data-fetch.yml` to use Node 18 so that our checks and data fetches can work until the problem with installing `re2` on Node 20 is fixed.

#### Related Issues

Failing checks on https://github.com/eslint/eslint.org/pull/483 and https://github.com/eslint/eslint.org/pull/482.

#### Is there anything you'd like reviewers to focus on?

Our builds on Netlify run on Node 16.14.0 so they should be fine for now. It seems that Netlify reads from [`package.engines`](https://github.com/eslint/eslint.org/blob/0f02c7044e262f367b7b4fdfb01fcb815cde9e3c/package.json#L13) where 16.14.0 was pinned in https://github.com/eslint/eslint.org/commit/a259464650785bcf33b4c56e74a86b9e31de8f99, I'm not sure why.

<!-- markdownlint-disable-file MD004 -->
