### PR TITLE
chore: add Biome to the suggested formatters

### DIFF
--- a/src/content/blog/2023-10-26-deprecating-formatting-rules.md
+++ b/src/content/blog/2023-10-26-deprecating-formatting-rules.md
@@ -124,6 +124,7 @@ We recommend using a source code formatter instead of ESLint for formatting your
 
 * [Prettier](https://prettier.io) - a JavaScript-based formatter with support for formatting a large number of languages
 * [dprint](https://dprint.dev) - a Rust-based formatter with support for a smaller set of languages
+* [Biome](https://biomejs.dev) - a Rust-based toolchain, that provides a formatter with a smaller set of languages
 
 If the idea of using a dedicated source code formatter doesn't appeal to you, you can also use [`@stylistic/eslint-plugin-js`](https://eslint.style/packages/js) for JavaScript or [`@stylistic/eslint-plugin-ts`](https://eslint.style/packages/ts) for TypeScript. These packages contain the deprecated formatting rules from the ESLint core and [`typescript-eslint`](https://typescript-eslint.io), respectively. The packages are maintained by [Anthony Fu](https://github.com/antfu), who has decided to continue maintaining these rules going forward. If you'd like to continue using the rules mentioned in this post, then we recommend switching to these packages.
 

--- a/src/content/blog/2023-10-26-deprecating-formatting-rules.md
+++ b/src/content/blog/2023-10-26-deprecating-formatting-rules.md
@@ -124,7 +124,7 @@ We recommend using a source code formatter instead of ESLint for formatting your
 
 * [Prettier](https://prettier.io) - a JavaScript-based formatter with support for formatting a large number of languages
 * [dprint](https://dprint.dev) - a Rust-based formatter with support for a smaller set of languages
-* [Biome](https://biomejs.dev) - a Rust-based toolchain, that provides a formatter with a smaller set of languages
+* [Biome](https://biomejs.dev) - a Rust-based toolchain, that provides a formatter with support for a smaller set of languages
 
 If the idea of using a dedicated source code formatter doesn't appeal to you, you can also use [`@stylistic/eslint-plugin-js`](https://eslint.style/packages/js) for JavaScript or [`@stylistic/eslint-plugin-ts`](https://eslint.style/packages/ts) for TypeScript. These packages contain the deprecated formatting rules from the ESLint core and [`typescript-eslint`](https://typescript-eslint.io), respectively. The packages are maintained by [Anthony Fu](https://github.com/antfu), who has decided to continue maintaining these rules going forward. If you'd like to continue using the rules mentioned in this post, then we recommend switching to these packages.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

To add another JS formatter to the list

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

A change to the blog post

#### Related Issues

None

#### Is there anything you'd like reviewers to focus on?

The addition of a new tool as alternative

<!-- markdownlint-disable-file MD004 -->
