### PR TITLE
fix: sliver sponsor image size is too large

### DIFF
--- a/src/assets/scss/sponsors.scss
+++ b/src/assets/scss/sponsors.scss
@@ -58,7 +58,7 @@
 .sponsors.sponsors--silver {
     picture,
     img {
-        max-height: 8rem;
+        max-height: 4rem;
     }
 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Currently Sliver Sponsor images are the same size as Platinum Sponsors and larger than Gold Sponsors. This is clearly not what we intended

#### What changes did you make? (Give an overview)

Reduce the size of the Sliver Sponsor's image.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
