### PR TITLE
fix: Add flex-basis and flex-grow to social icons and language switcher

### DIFF
--- a/src/assets/scss/components/language-switcher.scss
+++ b/src/assets/scss/components/language-switcher.scss
@@ -19,4 +19,7 @@
 
 .language-switcher {
     display: inline-flex;
+    flex-grow: 1;
+    flex-basis: 0;
+    justify-content: end;
 }

--- a/src/assets/scss/components/social-icons.scss
+++ b/src/assets/scss/components/social-icons.scss
@@ -1,4 +1,7 @@
 .eslint-social-icons {
+    flex-grow: 1;
+    flex-basis: 0;
+
     ul {
         margin: 0;
         padding: 0;


### PR DESCRIPTION
fix(footer): add flex-basis and flex-grow to social icons and language switcher

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
The theme switcher was offcentered because the language switcher is larger than the social icons section.

Before: 
![image](https://github.com/eslint/eslint.org/assets/82628932/c73fbba9-fe95-4df8-9866-1c2b8086cefa)

After:
![image](https://github.com/eslint/eslint.org/assets/82628932/19a19fda-c4a9-41a9-b187-1db4cb216b8d)


#### What changes did you make? (Give an overview)
I applied style changes on `language-switcher.scss` and `social-icons.scss`, adding `flex-grow` and `flex-basis` properties to each. On the first one, I also applied `justify-content: end`; to bring the language switcher to the end of the flex container. It was also tested on mobile, and still works fine.

#### Related Issues
None

#### Is there anything you'd like reviewers to focus on?
No

<!-- markdownlint-disable-file MD004 -->
