### PR TITLE
feat: Redirect flat config docs to main docs

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -32,6 +32,9 @@ eleventyExcludeFromCollections: true
 /docs/maintainer-guide/*            /docs/latest/maintainer-guide/:splat 301!
 /docs/developer-guide/*             /docs/latest/developer-guide/:splat 301!
 
+# Flat config redirects
+/docs/latest/use/configure/configuration-files-new           /docs/latest/use/configure/configuration-files 302!
+
 # Redirects for the ESLint IA Refactor (https://github.com/eslint/rfcs/pull/97)
 /docs/latest/user-guide/                                     /docs/latest/use/ 301!
 /docs/latest/user-guide/core-concepts                        /docs/latest/use/core-concepts 301!


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Redirecting https://eslint.org/docs/latest/use/configure/configuration-files-new to https://eslint.org/docs/latest/use/configure/configuration-files

This change should NOT be merged until we release v9.0.0 (final version, not alpha or beta) with updated docs.
https://github.com/eslint/eslint/pull/17840

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
