### PR TITLE
feat: show prerelease as the upcoming version

### DIFF
--- a/src/_data/stats.json
+++ b/src/_data/stats.json
@@ -6,6 +6,6 @@
     "lastCommitDate": "2023-12-19T06:51:59Z",
     "projectDependents": 16991422,
     "weeklyDownloads": 34931649,
-    "nextVersion": "v8.57.0",
+    "nextVersion": "v9.0.0-alpha.0",
     "nextVersionDate": "2023-12-29"
 }

--- a/tools/release-data.js
+++ b/tools/release-data.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Release-related data that needs to be hard-coded
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+/**
+ * - Set to `null` if the upcoming version is _not_ a prerelease,
+ *   regardless of the current version. The upcoming version can be
+ *   a regular minor release or a major release after prereleases.
+ * - Set to "alpha", "beta", or "rc" if the upcoming version is
+ *   an alpha/beta/rc prerelease, regardless of the current version.
+ * @type {null|string}
+ */
+const upcomingVersionPrereleaseType = "alpha";
+
+module.exports = {
+    upcomingVersionPrereleaseType
+};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added `release-data.js` file where we can manually specify whether the upcoming release will be a regular release or an alpha/beta/rc prerelease.
* Updated `fetch-stats.js` to use the above info when calculating the upcoming release version.

The usage should be simple:

* `"alpha"` = the upcoming release will be an alpha prerelease
* `"beta"` = the upcoming release will be a beta prerelease
* `"rc"` = the upcoming release will be an rc prerelease
* `null` otherwise.

I set it initially to `"alpha"`, as the upcoming release will indeed be an alpha prerelease.

There will be no need to change anything until we decide that the upcoming release will be a beta prerelease, at which point we should change the value to `"beta"`. The same for `"rc"`. When we decide that the upcoming release will be the final v9.0.0, we should set the value to `null` and leave it as such until v10 prereleases.

#### Related Issues

https://github.com/eslint/tsc-meetings/blob/main/notes/2023/2023-12-14.md

#### Is there anything you'd like reviewers to focus on?

This change aims to prepare _only_ the Upcoming Version field on https://eslint.org/ for the upcoming major release cycle. I'll open a separate issue to discuss whether we want some other changes as well (e.g., to show both the latest v8.56.0 and the current prerelease version). 

<!-- markdownlint-disable-file MD004 -->
