### PR TITLE
feat: show current prerelease version

### DIFF
--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -216,6 +216,7 @@ homepage:
   versions:
     title: ESLint Versionen
     latest: Aktuellste Version
+    latest_prerelease: Latest Prerelease Version
     upcoming: Nächste Version
     development: Entwicklung
     dateline: VERSION am DATE

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -212,6 +212,7 @@ homepage:
   versions:
     title: ESLint Versions
     latest: Latest Version
+    latest_prerelease: Latest Prerelease Version
     upcoming: Upcoming Version
     development: Development
     dateline: VERSION on DATE

--- a/src/_data/sites/es.yml
+++ b/src/_data/sites/es.yml
@@ -200,6 +200,7 @@ homepage:
   versions:
     title: Versiones de ESLint
     latest: Última versión
+    latest_prerelease: Latest Prerelease Version
     upcoming: Próxima versión
     development: Desarrollo
     dateline: VERSION en DATE

--- a/src/_data/sites/fr.yml
+++ b/src/_data/sites/fr.yml
@@ -206,6 +206,7 @@ homepage:
   versions:
     title: Versions d'ESLint
     latest: Dernière Version
+    latest_prerelease: Latest Prerelease Version
     upcoming: Prochaine Version
     development: Développement
     dateline: VERSION du DATE

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -191,6 +191,7 @@ homepage:
   versions:
     title: ESLint संस्करण
     latest: नवीनतम संस्करण
+    latest_prerelease: Latest Prerelease Version
     upcoming: आगामी संस्करण
     development: विकास संस्करण के तहत
     dateline: VERSION on DATE

--- a/src/_data/sites/ja.yml
+++ b/src/_data/sites/ja.yml
@@ -198,6 +198,7 @@ homepage:
   versions:
     title: ESLintバージョン
     latest: 最新バージョン
+    latest_prerelease: Latest Prerelease Version
     upcoming: 次バージョン
     development: 開発中バージョン
     dateline: VERSION（DATE）

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -201,6 +201,7 @@ homepage:
   versions:
     title: Versões do ESLint
     latest: Versão mais Recente
+    latest_prerelease: Latest Prerelease Version
     upcoming: Próxima Versão
     development: Desenvolvimento
     dateline: VERSION em DATE

--- a/src/_data/sites/zh-hans.yml
+++ b/src/_data/sites/zh-hans.yml
@@ -194,6 +194,7 @@ homepage:
   versions:
     title: ESLint 版本
     latest: 最新版本
+    latest_prerelease: Latest Prerelease Version
     upcoming: 即将到来的版本
     development: 开发中
     dateline: 于 DATE 发布 VERSION

--- a/src/_data/stats.json
+++ b/src/_data/stats.json
@@ -1,4 +1,6 @@
 {
+    "latestVersion": "v8.56.0",
+    "latestVersionDate": "2023-12-15T22:55:19Z",
     "currentVersion": "v8.56.0",
     "currentVersionDate": "2023-12-15T22:55:19Z",
     "currentVersionIsPrerelease": false,

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -70,6 +70,19 @@ eleventyExcludeFromCollections: true
                 <span id="eslint-versions-title" hidden>{{ site.homepage.versions.title }}</span>
                 <dt>{{ site.homepage.versions.latest }}</dt>
                 <dd>
+                    {% set version_date = stats.latestVersionDate | shortDateFromISO %}
+                    {% set dateline = site.homepage.versions.dateline | safe
+                        | replace("VERSION", "<a href=\"https://github.com/eslint/eslint/releases/tag/" + stats.latestVersion + "\" class=\"text-dark no-underline\">" + stats.latestVersion + "</a>")
+                        | replace("DATE", version_date)
+                    %}
+                    <svg width="16" height="8" viewBox="0 0 16 8" class="c-icon" role="img" aria-label="npm">
+                        <path d="M0 0.888885H16V6.22222H8V7.11111H4.44444V6.22222H0V0.888885ZM0.888889 5.33333H2.66667V2.66666H3.55556V5.33333H4.44444V1.77777H0.888889V5.33333ZM5.33333 1.77777V6.22222H7.11111V5.33333H8.88889V1.77777H5.33333ZM7.11111 2.66666H8V4.44444H7.11111V2.66666ZM9.77778 1.77777V5.33333H11.5556V2.66666H12.4444V5.33333H13.3333V2.66666H14.2222V5.33333H15.1111V1.77777H9.77778Z" fill="currentColor" />
+                    </svg>
+                    <span>{{ dateline }}</span>
+                </dd>
+                {% if stats.currentVersionIsPrerelease -%}
+                <dt>{{ site.homepage.versions.latest_prerelease }}</dt>
+                <dd>
                     {% set version_date = stats.currentVersionDate | shortDateFromISO %}
                     {% set dateline = site.homepage.versions.dateline | safe
                         | replace("VERSION", "<a href=\"https://github.com/eslint/eslint/releases/tag/" + stats.currentVersion + "\" class=\"text-dark no-underline\">" + stats.currentVersion + "</a>")
@@ -80,6 +93,7 @@ eleventyExcludeFromCollections: true
                     </svg>
                     <span>{{ dateline }}</span>
                 </dd>
+                {%- endif %}
                 <dt>{{ site.homepage.versions.upcoming }}</dt>
                 <dd>
                     {% set version_date = stats.nextVersionDate | shortDateFromISO %}
@@ -92,6 +106,7 @@ eleventyExcludeFromCollections: true
                     </svg>
                     <span>{{ dateline }}</span>
                 </dd>
+                {% if not stats.currentVersionIsPrerelease -%}
                 <dt>{{ site.homepage.versions.development }}</dt>
                 <dd>
                     {% set version_date = stats.lastCommitDate | shortDateFromISO %}
@@ -102,6 +117,7 @@ eleventyExcludeFromCollections: true
                     </svg>
                     <span>{{ dateline }}</span>
                 </dd>
+                {%- endif %}
             </dl>
         </div>
     </div>

--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -40,10 +40,12 @@ const fetchWeeklyNpmDownloads = util.promisify(downloadStats.get.lastWeek);
 async function fetchStatsFromGitHubAPI() {
     const { repository } = await graphql(`query {
         repository(owner:"eslint", name:"eslint") {
-            latestRelease {
-                publishedAt
-                isPrerelease
-                tagName
+            releases(first: 20, orderBy: { field: CREATED_AT, direction: DESC } ) {
+                nodes {
+                    publishedAt
+                    isPrerelease
+                    tagName
+                }
             }
             stargazerCount
             pushedAt
@@ -55,10 +57,15 @@ async function fetchStatsFromGitHubAPI() {
         }
     });
 
+    const [currentRelease] = repository.releases.nodes;
+    const latestRelease = repository.releases.nodes.find(({ isPrerelease }) => !isPrerelease);
+
     return {
-        currentVersion: repository.latestRelease.tagName,
-        currentVersionDate: repository.latestRelease.publishedAt,
-        currentVersionIsPrerelease: repository.latestRelease.isPrerelease,
+        latestVersion: latestRelease.tagName,
+        latestVersionDate: latestRelease.publishedAt,
+        currentVersion: currentRelease.tagName,
+        currentVersionDate: currentRelease.publishedAt,
+        currentVersionIsPrerelease: currentRelease.isPrerelease,
         stars: repository.stargazerCount,
         lastCommitDate: repository.pushedAt
     };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

Updates eslint.org homepage to show different versions when the current version is a prerelease:

Latest Version
Latest Prerelease Version
Upcoming Version

instead of (when the current version is not a prerelease):

Latest Version
Upcoming Version
Development

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated `tools/fetch-stats.js` to correctly fetch and calculate the current version and the latest version.
* Updated homepage to use this data and show different versions depending on whether the current release is prerelease, per the description.

#### Related Issues

https://github.com/eslint/eslint/issues/17893#issuecomment-1866717652

#### Is there anything you'd like reviewers to focus on?

We'll need translations for "Latest Prerelease Version".

<!-- markdownlint-disable-file MD004 -->
