### PR TITLE
chore: Update robots.txt to disallow crawling of non-latest docs

### DIFF
--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -6,4 +6,5 @@ eleventyExcludeFromCollections: true
 Sitemap: https://{{ site.hostname }}/sitemap-index.xml
 
 User-agent: *
-{% if "new." in site.hostname %}Disallow: /{% endif %}
+Disallow: /docs/next/
+Disallow: /docs/head/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

To ensure that only the latest version docs are crawled, disallowed crawling of `/docs/next/` and `/docs/head/`.

I also removed the old disallow when we were testing `new.eslint.org`.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
