### PR TITLE
feat: migrate playground to flat config

### DIFF
--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -1,5 +1,5 @@
 .playground__config__download-btn {
-    margin: 1rem;
+    margin: 1rem 0;
 }
 
 [data-config-section] {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -136,9 +136,23 @@ const App = () => {
     const [fix, setFix] = useState(false);
     const [options, setOptions] = useState(initialOptions);
 
+    // In some cases, Linter modifies `languageOptions`, so we'll deep-clone them
+    const optionsForLinter = {
+        ...options,
+        languageOptions: {
+            ...options.languageOptions,
+            parserOptions: {
+                ...options.languageOptions.parserOptions,
+                ecmaFeatures: {
+                    ...options.languageOptions.parserOptions.ecmaFeatures
+                }
+            }
+        }
+    };
+
     const lint = () => {
         try {
-            const { messages, output } = linter.verifyAndFix(text, options, { fix });
+            const { messages, output } = linter.verifyAndFix(text, optionsForLinter, { fix });
             let fatalMessage;
 
             if (messages && messages.length > 0 && messages[0].fatal) {
@@ -263,7 +277,7 @@ const App = () => {
                             tabIndex="0"
                             codeValue={text}
                             eslintInstance={linter}
-                            eslintOptions={options}
+                            eslintOptions={optionsForLinter}
                             onUpdate={debouncedOnUpdate}
                         />
                     </main>

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -53,7 +53,7 @@ const fillOptionsDefaults = options =>
             }, {})
         });
 
-const convertLegacyOptionsToFlatConfig = options => {
+const convertLegacyOptionsToFlatConfig = (options = {}) => {
 
     // If options object is empty, return it
     if (options && Object.keys(options).length === 0 && options.constructor === Object) {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -59,6 +59,18 @@ const convertLegacyOptionsToFlatConfig = options => {
 
         flatConfigOptions.languageOptions = restParserOptions;
 
+        /*
+         * Normalize ecmaVersion to support links with configs generated
+         * by the old demo (https://archive.eslint.org/demo)
+         */
+        if (
+            typeof parserOptions.ecmaVersion === "number" &&
+            parserOptions.ecmaVersion >= 6 &&
+            parserOptions.ecmaVersion < 2015
+        ) {
+            flatConfigOptions.languageOptions.ecmaVersion = parserOptions.ecmaVersion + 2009;
+        }
+
         if (ecmaFeatures) {
             flatConfigOptions.languageOptions.parserOptions = { ecmaFeatures };
         }

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -13,9 +13,8 @@ import debounce from "./utils/debounce";
 import "./scss/split-pane.scss";
 
 const linter = new Linter({ configType: "flat" });
-const legacyLinter = new Linter();
+const legacyLinter = new Linter({ configType: "eslintrc" });
 const rules = legacyLinter.getRules();
-
 const ruleNames = Array.from(rules.keys());
 const rulesMeta = Array.from(rules.entries()).reduce((result, [key, value]) => {
     result[key] = value.meta;

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -54,6 +54,10 @@ const fillOptionsDefaults = options =>
         });
 
 const convertLegacyOptionsToFlatConfig = options => {
+    if (typeof options.languageOptions !== "undefined" && typeof options.parserOptions === "undefined") {
+        return options;
+    }
+
     const { parserOptions } = options;
     const flatConfigOptions = {
         languageOptions: {
@@ -73,10 +77,6 @@ const convertLegacyOptionsToFlatConfig = options => {
 const getUrlState = () => {
     try {
         const urlOptions = JSON.parse(Unicode.decodeFromBase64(window.location.hash.replace(/^#/u, "")));
-
-        if (typeof urlOptions.options.languageOptions !== "undefined") {
-            return urlOptions;
-        }
 
         return { text: urlOptions.text, options: convertLegacyOptionsToFlatConfig(urlOptions.options) };
     } catch {
@@ -99,14 +99,7 @@ const App = () => {
     const { text: urlText, options: urlOptions } = getUrlState();
     const [text, setText] = useState(urlText || storedText || "/* eslint quotes: [\"error\", \"double\"] */\nconst a = 'b';");
     const [fix, setFix] = useState(false);
-
-    let flatConfigStoredOptions = storedOptions;
-
-    if (typeof storedOptions.languageOptions === "undefined") {
-        flatConfigStoredOptions = convertLegacyOptionsToFlatConfig(storedOptions);
-    }
-
-    const [options, setOptions] = useState(fillOptionsDefaults(urlText ? urlOptions || {} : flatConfigStoredOptions));
+    const [options, setOptions] = useState(fillOptionsDefaults(urlText ? urlOptions || {} : convertLegacyOptionsToFlatConfig(storedOptions)));
 
     const lint = () => {
         try {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -54,6 +54,13 @@ const fillOptionsDefaults = options =>
         });
 
 const convertLegacyOptionsToFlatConfig = options => {
+
+    // If options object is empty, return it
+    if (options && Object.keys(options).length === 0 && options.constructor === Object) {
+        return options;
+    }
+
+    // If options is already a flat config, return it
     if (typeof options.languageOptions !== "undefined" && typeof options.parserOptions === "undefined") {
         return options;
     }

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -22,11 +22,9 @@ const rulesMeta = Array.from(rules.entries()).reduce((result, [key, value]) => {
 }, {});
 
 const defaultLanguageOptions = {
-    ecmaVersion: "latest",
     parserOptions: {
         ecmaFeatures: {}
-    },
-    sourceType: "script"
+    }
 };
 
 const fillOptionsDefaults = options =>
@@ -35,8 +33,6 @@ const fillOptionsDefaults = options =>
             rules: {},
             ...options,
             languageOptions: {
-                ecmaVersion: "latest",
-                sourceType: "script",
                 ...options.languageOptions,
                 parserOptions: {
                     ecmaFeatures: {},
@@ -73,7 +69,7 @@ const convertLegacyOptionsToFlatConfig = (options = {}) => {
             parserOptions: {
                 ecmaFeatures: parserOptions.ecmaFeatures || {}
             },
-            sourceType: parserOptions.sourceType || "script"
+            sourceType: parserOptions.sourceType || "module"
         },
         rules: options.rules
 

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -25,7 +25,8 @@ const defaultLanguageOptions = {
     ecmaVersion: "latest",
     parserOptions: {
         ecmaFeatures: {}
-    }
+    },
+    sourceType: "script"
 };
 
 const fillOptionsDefaults = options =>
@@ -35,11 +36,12 @@ const fillOptionsDefaults = options =>
             ...options,
             languageOptions: {
                 ecmaVersion: "latest",
+                sourceType: "script",
+                ...options.languageOptions,
                 parserOptions: {
                     ecmaFeatures: {},
                     ...options.languageOptions?.parserOptions
-                },
-                ...options.languageOptions
+                }
             }
         }
         : {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -27,8 +27,10 @@ const defaultLanguageOptions = {
     }
 };
 
+const isEmptyObject = obj => obj && Object.keys(obj).length === 0 && obj.constructor === Object;
+
 const fillOptionsDefaults = options =>
-    (options
+    (!isEmptyObject(options)
         ? {
             rules: {},
             ...options,
@@ -53,7 +55,7 @@ const fillOptionsDefaults = options =>
 const convertLegacyOptionsToFlatConfig = (options = {}) => {
 
     // If options object is empty, return it
-    if (options && Object.keys(options).length === 0 && options.constructor === Object) {
+    if (isEmptyObject(options)) {
         return options;
     }
 
@@ -71,7 +73,7 @@ const convertLegacyOptionsToFlatConfig = (options = {}) => {
             },
             sourceType: parserOptions.sourceType || "module"
         },
-        rules: options.rules
+        rules: options.rules || {}
 
     };
 
@@ -120,10 +122,18 @@ const App = () => {
                 fatalMessage
             };
         } catch (error) {
+            if (error.message.includes("Oops! Something went wrong!")) {
+                return {
+                    messages: [],
+                    output: text,
+                    crashError: error
+                };
+            }
+
             return {
                 messages: [],
                 output: text,
-                error
+                validationError: error
             };
         }
     };
@@ -141,7 +151,7 @@ const App = () => {
         history.replaceState(null, null, url);
     }, [options, text]);
 
-    const { messages, output, fatalMessage, error: crashError, validationError } = lint();
+    const { messages, output, fatalMessage, crashError, validationError } = lint();
     const lintTime = Date.now();
     const isInvalidAutofix = fatalMessage && text !== output;
 

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -122,18 +122,18 @@ const App = () => {
                 fatalMessage
             };
         } catch (error) {
-            if (error.message.includes("Oops! Something went wrong!")) {
+            if (error.message.includes("Key \"rules\":")) {
                 return {
                     messages: [],
                     output: text,
-                    crashError: error
+                    validationError: error
                 };
             }
 
             return {
                 messages: [],
                 output: text,
-                validationError: error
+                crashError: error
             };
         }
     };

--- a/src/playground/components/CodeEditor.js
+++ b/src/playground/components/CodeEditor.js
@@ -5,18 +5,17 @@ import { bracketMatching } from "@codemirror/matchbrackets";
 import { javascript, esLint } from "@codemirror/lang-javascript";
 import { linter } from "../utils/codemirror-linter-extension";
 import { ESLintPlaygroundTheme, ESLintPlaygroundHighlightStyle } from "../utils/codemirror-theme";
-import { Linter as ESLint } from "../node_modules/eslint/lib/linter/";
 import "../scss/editor.scss";
 
-export default function CodeEditor({ codeValue, onUpdate, eslintOptions }) {
+export default function CodeEditor({ codeValue, onUpdate, eslintOptions, eslintInstance }) {
     const extensions = useMemo(() => [
         history(),
         bracketMatching(),
-        linter(esLint(new ESLint({ configType: "flat" }), { ...eslintOptions }), { delay: 0 }),
+        linter(esLint(eslintInstance, eslintOptions), { delay: 0 }),
         javascript(),
         ESLintPlaygroundTheme,
         ESLintPlaygroundHighlightStyle
-    ], [eslintOptions]);
+    ], [eslintOptions, eslintInstance]);
 
     return (
         <CodeMirror

--- a/src/playground/components/CodeEditor.js
+++ b/src/playground/components/CodeEditor.js
@@ -12,7 +12,7 @@ export default function CodeEditor({ codeValue, onUpdate, eslintOptions }) {
     const extensions = useMemo(() => [
         history(),
         bracketMatching(),
-        linter(esLint(new ESLint(), eslintOptions), { delay: 0 }),
+        linter(esLint(new ESLint({ configType: "flat" }), { ...eslintOptions }), { delay: 0 }),
         javascript(),
         ESLintPlaygroundTheme,
         ESLintPlaygroundHighlightStyle

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import Select, { components } from "react-select";
 import ShareURL from "./ShareURL";
-import { ECMA_FEATURES, ECMA_VERSIONS, SOURCE_TYPES } from "../utils/constants";
+import { ECMA_FEATURES, ECMA_VERSIONS, SOURCE_TYPES, CONFIG_FORMATS } from "../utils/constants";
 
 const customStyles = {
     singleValue: styles => ({
@@ -90,10 +90,12 @@ const customTheme = theme => ({
 export default function Configuration({ rulesMeta, eslintVersion, onUpdate, options, ruleNames, validationError }) {
     const [showVersion, setShowVersions] = useState(false);
     const [showRules, setShowRules] = useState(true);
+    const [configFileFormat, setConfigFileFormat] = useState("ESM");
 
     const sourceTypeOptions = SOURCE_TYPES.map(sourceType => ({ value: sourceType, label: sourceType }));
     const ECMAFeaturesOptions = ECMA_FEATURES.map(ecmaFeature => ({ value: ecmaFeature, label: ecmaFeature }));
     const ECMAVersionsOptions = ECMA_VERSIONS.map(ecmaVersion => ({ value: ecmaVersion === "latest" ? ecmaVersion : Number(ecmaVersion), label: ecmaVersion }));
+    const configFileFormatOptions = CONFIG_FORMATS.map(configFormat => ({ value: configFormat, label: configFormat }));
 
     // filter rules which are already added to the configuration
     const ruleNamesOptions = ruleNames.filter(ruleName => options.rules && !options.rules[ruleName]).map(ruleName => ({
@@ -156,6 +158,8 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         onUpdate(Object.assign({}, options));
     };
 
+    const configFileContent = `${configFileFormat === "esm" ? "export default" : "module.exports ="} ${JSON.stringify([options], null, 4)};`;
+
     return (
         <div className="playground__config-options__sections">
             <div className="playground__config-options__section">
@@ -179,7 +183,8 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                                 styles={customStyles}
                                 theme={theme => customTheme(theme)}
                                 defaultValue={
-                                    ECMAVersionsOptions.filter(ecmaVersion => options.languageOptions.ecmaVersion === ecmaVersion.value)}
+                                    ECMAVersionsOptions.filter(ecmaVersion => ecmaVersion.value === (options.languageOptions.ecmaVersion || "latest"))
+                                }
                                 options={ECMAVersionsOptions}
                                 onChange={selected => {
                                     options.languageOptions.ecmaVersion = selected.value;
@@ -194,11 +199,25 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}
-                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => options.languageOptions.sourceType === sourceTypeOption.value)}
+                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => sourceTypeOption.value === (options.languageOptions.sourceType || "module"))}
                             options={sourceTypeOptions}
                             onChange={selected => {
                                 options.languageOptions.sourceType = selected.value;
                                 onUpdate(Object.assign({}, options));
+                            }}
+
+                        />
+                    </label>
+                    <label className="c-field" htmlFor="config-format">
+                        <span className="label__text">Configuration File Format</span>
+                        <Select
+                            isSearchable={false}
+                            styles={customStyles}
+                            theme={theme => customTheme(theme)}
+                            defaultValue={configFileFormatOptions.filter(formatOption => formatOption.value === "ESM")}
+                            options={configFileFormatOptions}
+                            onChange={selected => {
+                                setConfigFileFormat(selected.value);
                             }}
 
                         />
@@ -343,6 +362,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                     </div>
                 </div>
             </div> */}
+
             <a
                 href={
                     `data:application/json;charset=utf-8,${encodeURIComponent(configFileContent)}`
@@ -350,7 +370,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                 download="eslint.config.js"
                 className="c-btn c-btn--primary playground__config__download-btn"
             >
-                Download this config file
+                Download this config file ({configFileFormat})
             </a>
         </div>
     );

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -113,7 +113,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
 
 
     const handleRuleChange = () => {
-        const rules = { ...options.rules };
+        const rules = { ...(options.rules || {}) };
 
         selectedRules.forEach(selectedRule => {
             if (ruleNames.includes(selectedRule)) {
@@ -140,7 +140,8 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         );
     };
 
-    const allRulesSelected = Object.keys(options.rules).length === ruleNames.length;
+    const allRulesSelected = Object.keys(options.rules || {}).length === ruleNames.length;
+
 
     const selectAll = () => {
         if (allRulesSelected) {

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -92,6 +92,8 @@ const defaultOption = {
     label: "(default)"
 };
 
+const isEmpty = obj => Object.keys(obj).length === 0;
+
 export default function Configuration({ rulesMeta, eslintVersion, onUpdate, options, ruleNames, validationError }) {
     const [showVersion, setShowVersions] = useState(false);
     const [showRules, setShowRules] = useState(true);
@@ -164,7 +166,19 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         onUpdate(Object.assign({}, options));
     };
 
-    const configFileContent = `${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([options], null, 4)};`;
+    // Remove empty objects from download configuration
+    const hasEcmaFeatures = !isEmpty(options.languageOptions.parserOptions.ecmaFeatures);
+    const optionsForConfigFile = {
+        rules: isEmpty(options.rules) ? void 0 : options.rules,
+        languageOptions: Object.keys(options.languageOptions).length === 1 && !hasEcmaFeatures
+            ? void 0
+            : {
+                ...options.languageOptions,
+                parserOptions: !hasEcmaFeatures ? void 0 : options.languageOptions.parserOptions
+            }
+    };
+
+    const configFileContent = `${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([optionsForConfigFile], null, 4)};`;
 
     return (
         <div className="playground__config-options__sections">

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -208,20 +208,6 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
 
                         />
                     </label>
-                    <label className="c-field" htmlFor="config-format">
-                        <span className="label__text">Configuration File Format</span>
-                        <Select
-                            isSearchable={false}
-                            styles={customStyles}
-                            theme={theme => customTheme(theme)}
-                            defaultValue={configFileFormatOptions.filter(formatOption => formatOption.value === "ESM")}
-                            options={configFileFormatOptions}
-                            onChange={selected => {
-                                setConfigFileFormat(selected.value);
-                            }}
-
-                        />
-                    </label>
                     <div className="combo">
                         <label id="ecma-combo-label" htmlFor="ECMA Feature" className="label__text">ECMA Features</label>
                         <Select
@@ -363,15 +349,32 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                 </div>
             </div> */}
 
-            <a
-                href={
-                    `data:application/json;charset=utf-8,${encodeURIComponent(configFileContent)}`
-                }
-                download="eslint.config.js"
-                className="c-btn c-btn--primary playground__config__download-btn"
-            >
-                Download this config file ({configFileFormat})
-            </a>
+            <div className="playground__config-options__section">
+                <div data-config-section>
+                    <label className="c-field" htmlFor="config-format">
+                        <span className="label__text">Configuration File Format</span>
+                        <Select
+                            isSearchable={false}
+                            styles={customStyles}
+                            theme={theme => customTheme(theme)}
+                            defaultValue={configFileFormatOptions.filter(formatOption => formatOption.value === "ESM")}
+                            options={configFileFormatOptions}
+                            onChange={selected => {
+                                setConfigFileFormat(selected.value);
+                            }}
+                        />
+                    </label>
+                    <a
+                        href={
+                            `data:application/json;charset=utf-8,${encodeURIComponent(configFileContent)}`
+                        }
+                        download="eslint.config.js"
+                        className="c-btn c-btn--primary playground__config__download-btn"
+                    >
+                        Download this config file
+                    </a>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -113,7 +113,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
 
 
     const handleRuleChange = () => {
-        const rules = { ...(options.rules || {}) };
+        const rules = { ...options.rules };
 
         selectedRules.forEach(selectedRule => {
             if (ruleNames.includes(selectedRule)) {
@@ -140,7 +140,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         );
     };
 
-    const allRulesSelected = Object.keys(options.rules || {}).length === ruleNames.length;
+    const allRulesSelected = Object.keys(options.rules).length === ruleNames.length;
 
 
     const selectAll = () => {

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -158,7 +158,7 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         onUpdate(Object.assign({}, options));
     };
 
-    const configFileContent = `${configFileFormat === "esm" ? "export default" : "module.exports ="} ${JSON.stringify([options], null, 4)};`;
+    const configFileContent = `${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([options], null, 4)};`;
 
     return (
         <div className="playground__config-options__sections">

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -87,14 +87,19 @@ const customTheme = theme => ({
     }
 });
 
+const defaultOption = {
+    value: "default",
+    label: "(default)"
+};
+
 export default function Configuration({ rulesMeta, eslintVersion, onUpdate, options, ruleNames, validationError }) {
     const [showVersion, setShowVersions] = useState(false);
     const [showRules, setShowRules] = useState(true);
     const [configFileFormat, setConfigFileFormat] = useState("ESM");
 
-    const sourceTypeOptions = SOURCE_TYPES.map(sourceType => ({ value: sourceType, label: sourceType }));
+    const sourceTypeOptions = [defaultOption, ...SOURCE_TYPES.map(sourceType => ({ value: sourceType, label: sourceType }))];
     const ECMAFeaturesOptions = ECMA_FEATURES.map(ecmaFeature => ({ value: ecmaFeature, label: ecmaFeature }));
-    const ECMAVersionsOptions = ECMA_VERSIONS.map(ecmaVersion => ({ value: ecmaVersion === "latest" ? ecmaVersion : Number(ecmaVersion), label: ecmaVersion }));
+    const ECMAVersionsOptions = [defaultOption, ...ECMA_VERSIONS.map(ecmaVersion => ({ value: ecmaVersion === "latest" ? ecmaVersion : Number(ecmaVersion), label: ecmaVersion }))];
     const configFileFormatOptions = CONFIG_FORMATS.map(configFormat => ({ value: configFormat, label: configFormat }));
 
     // filter rules which are already added to the configuration
@@ -184,11 +189,16 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                                 styles={customStyles}
                                 theme={theme => customTheme(theme)}
                                 defaultValue={
-                                    ECMAVersionsOptions.filter(ecmaVersion => ecmaVersion.value === (options.languageOptions.ecmaVersion || "latest"))
+                                    ECMAVersionsOptions.filter(ecmaVersion => ecmaVersion.value === (options.languageOptions.ecmaVersion || "default"))
                                 }
                                 options={ECMAVersionsOptions}
                                 onChange={selected => {
-                                    options.languageOptions.ecmaVersion = selected.value;
+                                    if (selected.value === "default") {
+                                        delete options.languageOptions.ecmaVersion;
+                                    } else {
+                                        options.languageOptions.ecmaVersion = selected.value;
+                                    }
+
                                     onUpdate(Object.assign({}, options));
                                 }}
                             />
@@ -200,10 +210,15 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}
-                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => sourceTypeOption.value === (options.languageOptions.sourceType || "module"))}
+                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => sourceTypeOption.value === (options.languageOptions.sourceType || "default"))}
                             options={sourceTypeOptions}
                             onChange={selected => {
-                                options.languageOptions.sourceType = selected.value;
+                                if (selected.value === "default") {
+                                    delete options.languageOptions.sourceType;
+                                } else {
+                                    options.languageOptions.sourceType = selected.value;
+                                }
+
                                 onUpdate(Object.assign({}, options));
                             }}
 

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -140,7 +140,6 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
 
     const allRulesSelected = Object.keys(options.rules).length === ruleNames.length;
 
-
     const selectAll = () => {
         if (allRulesSelected) {
             options.rules = {};
@@ -156,7 +155,6 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
         }
         onUpdate(Object.assign({}, options));
     };
-
 
     return (
         <div className="playground__config-options__sections">
@@ -347,9 +345,9 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
             </div> */}
             <a
                 href={
-                    `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(options, null, 4))}`
+                    `data:application/json;charset=utf-8,${encodeURIComponent(configFileContent)}`
                 }
-                download=".eslintrc.json"
+                download="eslint.config.js"
                 className="c-btn c-btn--primary playground__config__download-btn"
             >
                 Download this config file

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import Select, { components } from "react-select";
 import ShareURL from "./ShareURL";
-import { ECMA_FEATURES, ECMA_VERSIONS, SOURCE_TYPES, ENV_NAMES } from "../utils/constants";
+import { ECMA_FEATURES, ECMA_VERSIONS, SOURCE_TYPES } from "../utils/constants";
 
 const customStyles = {
     singleValue: styles => ({
@@ -88,16 +88,12 @@ const customTheme = theme => ({
 });
 
 export default function Configuration({ rulesMeta, eslintVersion, onUpdate, options, ruleNames, validationError }) {
-
     const [showVersion, setShowVersions] = useState(false);
-    const [showEnvironment, setShowEnvironment] = useState(false);
     const [showRules, setShowRules] = useState(true);
-
 
     const sourceTypeOptions = SOURCE_TYPES.map(sourceType => ({ value: sourceType, label: sourceType }));
     const ECMAFeaturesOptions = ECMA_FEATURES.map(ecmaFeature => ({ value: ecmaFeature, label: ecmaFeature }));
     const ECMAVersionsOptions = ECMA_VERSIONS.map(ecmaVersion => ({ value: ecmaVersion === "latest" ? ecmaVersion : Number(ecmaVersion), label: ecmaVersion }));
-    const envNamesOptions = ENV_NAMES.map(envName => ({ value: envName, label: envName }));
 
     // filter rules which are already added to the configuration
     const ruleNamesOptions = ruleNames.filter(ruleName => options.rules && !options.rules[ruleName]).map(ruleName => ({
@@ -184,10 +180,11 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                                 isSearchable={false}
                                 styles={customStyles}
                                 theme={theme => customTheme(theme)}
-                                defaultValue={ECMAVersionsOptions.filter(ecmaVersion => options.parserOptions.ecmaVersion === ecmaVersion.value)}
+                                defaultValue={
+                                    ECMAVersionsOptions.filter(ecmaVersion => options.languageOptions.ecmaVersion === ecmaVersion.value)}
                                 options={ECMAVersionsOptions}
                                 onChange={selected => {
-                                    options.parserOptions.ecmaVersion = selected.value;
+                                    options.languageOptions.ecmaVersion = selected.value;
                                     onUpdate(Object.assign({}, options));
                                 }}
                             />
@@ -199,10 +196,10 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}
-                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => options.parserOptions.sourceType === sourceTypeOption.value)}
+                            defaultValue={sourceTypeOptions.filter(sourceTypeOption => options.languageOptions.sourceType === sourceTypeOption.value)}
                             options={sourceTypeOptions}
                             onChange={selected => {
-                                options.parserOptions.sourceType = selected.value;
+                                options.languageOptions.sourceType = selected.value;
                                 onUpdate(Object.assign({}, options));
                             }}
 
@@ -213,44 +210,23 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                         <Select
                             isClearable
                             isMulti
-                            defaultValue={ECMAFeaturesOptions.filter(ecmaFeatureName => options.parserOptions.ecmaFeatures[ecmaFeatureName.value])}
+                            defaultValue={
+                                ECMAFeaturesOptions.filter(ecmaFeatureName => options.languageOptions.parserOptions.ecmaFeatures[ecmaFeatureName.value])
+                            }
                             isSearchable={false}
                             styles={customStyles}
                             theme={theme => customTheme(theme)}
                             options={ECMAFeaturesOptions}
                             onChange={selectedOptions => {
-                                options.parserOptions.ecmaFeatures = {};
+                                options.languageOptions.parserOptions.ecmaFeatures = {};
                                 selectedOptions.forEach(selected => {
-                                    options.parserOptions.ecmaFeatures[selected.value] = true;
+                                    options.languageOptions.parserOptions.ecmaFeatures[selected.value] = true;
                                 });
                                 onUpdate(Object.assign({}, options));
                             }}
                         />
                     </div>
                 </div>}
-            </div>
-            <div className="playground__config-options__section">
-                <button className="playground-toggle c-btn c-btn--ghost" onClick={() => setShowEnvironment(currentValue => !currentValue)}>
-                    <h2 data-config-section-title>Environments</h2>
-                    <svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="currentColor" style={{ transform: showEnvironment ? "rotate(180deg)" : null }}><path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path></svg>
-                </button>
-                {showEnvironment && <div data-config-section>
-                    <Select
-                        isMulti
-                        styles={customStyles}
-                        theme={theme => customTheme(theme)}
-                        defaultValue={envNamesOptions.filter(envName => options.env[envName.value])}
-                        options={envNamesOptions}
-                        onChange={selectedOptions => {
-                            options.env = {};
-                            selectedOptions.forEach(selected => {
-                                options.env[selected.value] = true;
-                            });
-                            onUpdate(Object.assign({}, options));
-                        }}
-                    />
-                </div>
-                }
             </div>
             <div className="playground__config-options__section playground__config-options__section--rules">
                 <button className="playground-toggle c-btn c-btn--ghost" onClick={() => setShowRules(currentValue => !currentValue)}>

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -5,7 +5,6 @@
     "description": "The codebase for the ESLint PLayground (play.eslint.org)",
     "license": "MIT",
     "dependencies": {
-        "@eslint/eslintrc": "latest",
         "eslint": "latest"
     }
 }

--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -23,3 +23,8 @@ export const SOURCE_TYPES = [
     "module",
     "commonjs"
 ];
+
+export const CONFIG_FORMATS = [
+    "CommonJS",
+    "ESM"
+];

--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -4,37 +4,6 @@ export const ECMA_FEATURES = [
     "impliedStrict"
 ];
 
-export const ENV_NAMES = [
-    "browser",
-    "node",
-    "commonjs",
-    "shared-node-browser",
-    "worker",
-    "amd",
-    "mocha",
-    "jasmine",
-    "jest",
-    "phantomjs",
-    "jquery",
-    "qunit",
-    "prototypejs",
-    "shelljs",
-    "meteor",
-    "mongo",
-    "protractor",
-    "applescript",
-    "nashorn",
-    "serviceworker",
-    "atomtest",
-    "embertest",
-    "webextensions",
-    "es6",
-    "es2017",
-    "es2020",
-    "es2021",
-    "greasemonkey"
-];
-
 export const ECMA_VERSIONS = [
     "3",
     "5",
@@ -51,5 +20,6 @@ export const ECMA_VERSIONS = [
 
 export const SOURCE_TYPES = [
     "script",
-    "module"
+    "module",
+    "commonjs"
 ];

--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -15,6 +15,8 @@ export const ECMA_VERSIONS = [
     "2020",
     "2021",
     "2022",
+    "2023",
+    "2024",
     "latest"
 ];
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Migration of the online playground to use flat config system.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Update playground to use flat config.
- Removed environments.
- Supports existing links to the Playground by translating configurations to the new format.
- Updated download configuration functionality
   - ~If `sourceType` is `module` then the downloaded config is in the ESM format otherwise it's in the CommonJS format.~
   - Added an option to select config file format.
 
<img width="378" alt="Screenshot 2024-01-26 at 4 38 58 PM" src="https://github.com/eslint/eslint.org/assets/46647141/c4251d02-78d7-463d-88ae-f3943ba4fcac">


#### Related Issues

Fix https://github.com/eslint/eslint.org/issues/507

#### Is there anything you'd like reviewers to focus on?
Should we update the default value for `sourceType` to `module`?

<!-- markdownlint-disable-file MD004 -->
