### PR TITLE
feat: account for backports when calculating versions

### DIFF
--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -57,10 +57,50 @@ async function fetchStatsFromGitHubAPI() {
         }
     });
 
+    /*
+     * We want to find:
+     *
+     *     1. `latestRelease` - This is the release tagged `latest` on the npm.
+     *         For example, 8.56.0 or 9.0.0.
+     *         In the terms of semver, this is the highest non-prerelease version. 
+     *     2. `currentRelease` - This is the release with the newest features.
+     *         This is normally the same as `latestRelease` (for example, 8.56.0 or 9.0.0),
+     *         but if we are in the process of publishing prereleases of the upcoming
+     *         major version, this is the most recent prerelease (for example, 9.0.0-alpha.2),
+     *         the one tagged `next` on the npm.
+     *         In the terms of semver, this is the highest version.
+     * 
+     * So, we need to find the highest version and the highest non-prerelease version.
+     * We're fetching releases from GitHub, which returns them ordered by creation date.
+     * This order typically already matches the semver order. However, if we've recently released
+     * some backport versions (e.g., v8.57.0 after 9.0.0-alpha.2), the order in the fetched 
+     * list will not follow semver:
+     * 
+     *     8.57.0
+     *     9.0.0-alpha.2
+     *     9.0.0-alpha.1 
+     *     9.0.0-alpha.0
+     *     8.56.0
+     *     ...
+     * 
+     * To account for this case, we'll first sort versions by semver, in descending order:
+     * 
+     *     9.0.0-alpha.2
+     *     9.0.0-alpha.1 
+     *     9.0.0-alpha.0
+     *     8.57.0
+     *     8.56.0
+     *     ... 
+     * 
+     */
     const releases = repository.releases.nodes.toSorted(
         (first, second) => semver.rcompare(first.tagName, second.tagName)
     );
 
+    /*
+     * Now we know that the first version in the list is the highest version, and that
+     * the first non-prerelease version in the list is the highest non-prerelease version.
+     */
     const [currentRelease] = releases;
     const latestRelease = releases.find(({ isPrerelease }) => !isPrerelease);
 

--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -57,8 +57,12 @@ async function fetchStatsFromGitHubAPI() {
         }
     });
 
-    const [currentRelease] = repository.releases.nodes;
-    const latestRelease = repository.releases.nodes.find(({ isPrerelease }) => !isPrerelease);
+    const releases = repository.releases.nodes.toSorted(
+        (first, second) => semver.rcompare(first.tagName, second.tagName)
+    );
+
+    const [currentRelease] = releases;
+    const latestRelease = releases.find(({ isPrerelease }) => !isPrerelease);
 
     return {
         latestVersion: latestRelease.tagName,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Updates logic that calculates ESLint versions for the eslint.org homepage to account for backport versions.

#### What changes did you make? (Give an overview)

Updated `tools/fetch-stats.js` to sort fetched releases by `semver.rcompare` before proceeding with the calculations. This specifically account for the case that the most recently published version is a backport.

#### Related Issues

https://github.com/eslint/eslint/issues/17966

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
