### PR TITLE
fix: no-js dark theme bugs

### DIFF
--- a/src/assets/scss/no-js.scss
+++ b/src/assets/scss/no-js.scss
@@ -1,0 +1,45 @@
+@media (prefers-color-scheme: dark) {
+    .no-js {
+        pre[class*="language-"] {
+            color: var(--color-neutral-100);
+        }
+
+        .token {
+            &.comment,
+            .prolog,
+            .doctype,
+            .cdata {
+                color: #8e9fae;
+            }
+        }
+
+        .rule__categories,
+        .rule__status {
+            background: var(--body-background-color);
+        }
+
+        .logo-component {
+            fill: #fff;
+        }
+
+        #logo-center {
+            opacity: 0.6;
+        }
+
+        .sponsors.sponsors {
+            img {
+                background-color: #fff;
+                border-radius: var(--border-radius);
+            }
+        }
+
+        .label__text.label__text {
+            color: var(--color-neutral-100);
+        }
+
+        .donation-plan__github-logo {
+            -webkit-filter: invert(100%);
+            filter: invert(100%);
+        }
+    }
+}

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -40,3 +40,5 @@
 @import "components/popup";
 
 @import "utilities";
+
+@import "no-js";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
similar to https://github.com/eslint/eslint/pull/18071

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/eslint/eslint.org/assets/30730124/35a098d4-1322-48a3-908e-4c4589665ac2) |  ![image](https://github.com/eslint/eslint.org/assets/30730124/5e2a4516-4b4d-47bc-953c-7e413d1c8dac) |
| ![image](https://github.com/eslint/eslint.org/assets/30730124/432ac361-d62f-46ec-b0a4-218b89831bf9) | ![image](https://github.com/eslint/eslint.org/assets/30730124/2b1577d8-86a2-4a71-816e-fc1fef584b8f) |
| ![image](https://github.com/eslint/eslint.org/assets/30730124/f3d5ed2f-2ac1-45ff-9bd2-3e076dc4bfb1) | ![image](https://github.com/eslint/eslint.org/assets/30730124/9288956b-7039-420d-bdf7-58b86b9b75ef) |
| ![image](https://github.com/eslint/eslint.org/assets/30730124/8ac3c5c6-b896-48ab-bcb1-18cfaadc8b54) | ![image](https://github.com/eslint/eslint.org/assets/30730124/61b8d859-b489-4947-b1b4-3ac6d866ce14) |
| ![image](https://github.com/eslint/eslint.org/assets/30730124/ddd5e835-ba68-404d-8cee-04e0b88620cf) | ![image](https://github.com/eslint/eslint.org/assets/30730124/51602c15-b18c-4666-b715-612b251e46bd) |



#### Related Issues

#### Is there anything you'd like reviewers to focus on?
I have addressed the identified issues. Feel free to add if anything missing.

<!-- markdownlint-disable-file MD004 -->
