### PR TITLE
feat: enable `docs/v8.x`

### DIFF
--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: latest--docs-eslint.netlify.app
   docs_head: docs-eslint.netlify.app
   docs_next: next--docs-eslint.netlify.app
+  docs_v8: v8.x--docs-eslint.netlify.app
   blog: true
 redirects:
   - from: https://cn.eslint.org/*

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -20,7 +20,7 @@ locals:
   docs_latest: latest--docs-eslint.netlify.app
   docs_head: docs-eslint.netlify.app
   docs_next: next--docs-eslint.netlify.app
-  docs_v8: v8.x--docs-eslint.netlify.app
+  docs_v8: v8-x--docs-eslint.netlify.app
   blog: true
 redirects:
   - from: https://cn.eslint.org/*

--- a/src/_data/sites/es.yml
+++ b/src/_data/sites/es.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/fr.yml
+++ b/src/_data/sites/fr.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/ja.yml
+++ b/src/_data/sites/ja.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: false
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/_data/sites/zh-hans.yml
+++ b/src/_data/sites/zh-hans.yml
@@ -20,6 +20,7 @@ locals:
   docs_latest: zh-hans-docs.netlify.app
   docs_head: false
   docs_next: false
+  docs_v8: false
   blog: false
 
 #------------------------------------------------------------------------------

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -97,6 +97,13 @@ eleventyExcludeFromCollections: true
 /docs/head/*                        https://eslint.org/docs/head/:splat 302!
 {% endif %}
 
+# Docs for the latest v8.x
+{% if site.locals.docs_v8 %}
+/docs/v8.x/*                        https://{{ site.locals.docs_v8 }}/:splat 200!
+{% else %}
+/docs/v8.x/*                        https://eslint.org/docs/v8.x/:splat 302!
+{% endif %}
+
 # Docs for the current prerelease
 {% if site.locals.docs_next %}
 /docs/next/*                        https://{{ site.locals.docs_next }}/:splat 200!


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Updates the redirects file to enable `/docs/v8.x/`, where we'll have v8.57.0 docs.

#### What changes did you make? (Give an overview)

Copy-pasted and adjusted the code that handles `/docs/head/`.

#### Related Issues

https://github.com/eslint/eslint/issues/18229

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
