### PR TITLE
feat: redirect `docs/next` to `docs/latest`

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -98,11 +98,8 @@ eleventyExcludeFromCollections: true
 {% endif %}
 
 # Docs for the current prerelease
-{% if site.locals.docs_next %}
-/docs/next/*                        https://{{ site.locals.docs_next }}/:splat 200!
-{% else %}
-/docs/next/*                        https://eslint.org/docs/next/:splat 302!
-{% endif %}
+# As there is currently no active prerelease, redirect to latest docs
+/docs/next/*                        https://eslint.org/docs/latest/:splat 302!
 
 {% if site.locals.blog == false %}
 # Redirect blog back to English site


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Redirects `docs/next/*` to `docs/latest/*`. 

#### Related Issues

https://github.com/eslint/eslint/issues/18228

#### Is there anything you'd like reviewers to focus on?

This should _not_ be merged before we release ESLint v9.0.0 final.

This should be merged right after we release ESLint v9.0.0 final.

<!-- markdownlint-disable-file MD004 -->
