### PR TITLE
fix: correct upcoming release date after patch releases

### DIFF
--- a/src/_data/stats.json
+++ b/src/_data/stats.json
@@ -4,10 +4,10 @@
     "currentVersion": "v9.1.1",
     "currentVersionDate": "2024-04-22T19:23:14Z",
     "currentVersionIsPrerelease": false,
-    "stars": 24270,
-    "lastCommitDate": "2024-04-23T02:08:58Z",
-    "projectDependents": 19255405,
+    "stars": 24271,
+    "lastCommitDate": "2024-04-23T10:56:02Z",
+    "projectDependents": 19264226,
     "weeklyDownloads": 38275199,
     "nextVersion": "v9.2.0",
-    "nextVersionDate": "2024-05-10"
+    "nextVersionDate": "2024-05-03"
 }

--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -194,9 +194,21 @@ async function fetchGitHubNetworkStats() {
 
     stats.nextVersion = `v${nextVersion}`;
 
-    // approximate next release date
-    stats.nextVersionDate = DateTime.fromISO(stats.currentVersionDate)
-        .plus({ weeks: 2 }).endOf("week").minus({ days: 2 }).toISODate();
+    /*
+    * Calculate next release date.
+    * We do scheduled releases every two weeks, on Fridays.
+    * One of the scheduled release dates was Friday, 2024-01-12. We'll use that date as the baseline.
+    * So, all planned releases are expected to be on 2024-01-12 + n * 14 days.
+    * Now we'll find the first such day after the current version date.
+    */
+    const baseDate = DateTime.fromISO("2024-01-12");
+    const currentVersionDate = DateTime.fromISO(stats.currentVersionDate);
+
+    stats.nextVersionDate = currentVersionDate
+        .plus({
+            days: 14 - currentVersionDate.diff(baseDate, "days").days % 14
+        })
+        .toISODate();
 
     await fs.writeFile(statsFilePath, JSON.stringify(stats, null, 4), { encoding: "utf8" });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

Logic that calculates the upcoming release date didn't account for Monday's patch releases, so we currently have a wrong date on the site:

![image](https://github.com/eslint/eslint.org/assets/44349756/e4c8431c-681e-4ef8-95bb-ccb9380d708c)

It should be `3 May`, not `10 May`.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the logic to calculate the upcoming release date by using the fact that we have a release every second Friday starting from a certain date.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
