### PR TITLE
fix: support `node:` protocol when building Playground

### DIFF
--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -5,6 +5,6 @@
     "description": "The codebase for the ESLint PLayground (play.eslint.org)",
     "license": "MIT",
     "dependencies": {
-        "eslint": "github:eslint/eslint"
+        "eslint": "latest"
     }
 }

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -5,6 +5,6 @@
     "description": "The codebase for the ESLint PLayground (play.eslint.org)",
     "license": "MIT",
     "dependencies": {
-        "eslint": "latest"
+        "eslint": "github:eslint/eslint"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("path");
+const webpack = require("webpack");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 
 /**
@@ -28,7 +29,15 @@ module.exports = (env, { mode }) => ({
         extensions: [".js", ".jsx"],
         mainFields: ["browser", "main", "module"]
     },
-    plugins: [new NodePolyfillPlugin()],
+    plugins: [
+        new webpack.NormalModuleReplacementPlugin(
+            /^node:/u,
+            resource => {
+                resource.request = resource.request.replace(/^node:/u, "");
+            }
+        ),
+        new NodePolyfillPlugin()
+    ],
     ...(mode === "development" ? { devtool: "source-map" } : {}),
     module: {
         rules: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Updates webpack config to support `node:` protocol (e.g., `require("node:path")`).

This change is necessary in order to build the Playground from the upcoming ESLint v9.3.0 because it will use the `node:` protocol.

#### What changes did you make? (Give an overview)

Updated webpack config like in https://github.com/eslint/eslint/pull/18434, as recommended in https://github.com/webpack/webpack/issues/13290.

#### Related Issues

https://github.com/eslint/eslint/pull/18434

#### Is there anything you'd like reviewers to focus on?

Check that the playground is working properly in the deploy preview.

<!-- markdownlint-disable-file MD004 -->
