### PR TITLE
feat: redirect `docs/v9.x` to `docs/latest`

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -40,7 +40,7 @@ eleventyExcludeFromCollections: true
 /docs/latest/user-guide/core-concepts                        /docs/latest/use/core-concepts 301!
 /docs/latest/user-guide/configuring/                         /docs/latest/use/configure/ 301!
 /docs/latest/user-guide/configuring/configuration-files-new  /docs/latest/use/configure/configuration-files-new 301!
-/docs/latest/user-guide/configuring/configuration-files     /docs/latest/use/configure/configuration-files 301!
+/docs/latest/user-guide/configuring/configuration-files      /docs/latest/use/configure/configuration-files 301!
 /docs/latest/user-guide/configuring/language-options         /docs/latest/use/configure/language-options 301!
 /docs/latest/user-guide/configuring/rules                    /docs/latest/use/configure/rules 301!
 /docs/latest/user-guide/configuring/plugins                  /docs/latest/use/configure/plugins 301!
@@ -106,6 +106,10 @@ eleventyExcludeFromCollections: true
 {% else %}
 /docs/v8.x/*                        https://eslint.org/docs/v8.x/:splat 302!
 {% endif %}
+
+# Docs for the latest v9.x
+# Redirect to latest docs while v9.x is the latest release
+/docs/v9.x/*                        https://eslint.org/docs/latest/:splat 302!
 
 # Docs for the current prerelease
 # As there is currently no active prerelease, redirect to latest docs


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

Fixes #545

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a redirect from `/docs/v9.x/*` to the official latest docs URL in the redirects template.

#### Related Issues

#545

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
