### PR TITLE
docs: fix predefined configs example in FlatConfig announcement according to later breaking changes (because Google shows this page)

### DIFF
--- a/src/content/blog/2022-08-05-new-config-system-part-2.md
+++ b/src/content/blog/2022-08-05-new-config-system-part-2.md
@@ -59,7 +59,7 @@ export default [
         rules: {
             "semi": "error",
             "no-unused-vars": "error"
-        }  
+        }
     }
 ];
 ```
@@ -80,7 +80,7 @@ export default [
         rules: {
             "semi": "error",
             "no-unused-vars": "error"
-        }  
+        }
     }
 ];
 ```
@@ -99,7 +99,7 @@ export default [
         rules: {
             "semi": "error",
             "no-unused-vars": "error"
-        }  
+        }
     }
 ];
 ```
@@ -117,14 +117,14 @@ export default [
         rules: {
             "semi": "error",
             "no-unused-vars": "error"
-        }  
+        }
     },
     {
         files: ["**/*.js"],
         rules: {
             "no-undef": "error",
             "semi": "warn"
-        }  
+        }
     }
 ];
 ```
@@ -143,14 +143,14 @@ export default [
         rules: {
             "semi": "error",
             "no-unused-vars": "error"
-        }  
+        }
     },
     {
         files: ["**/*.js"],
         rules: {
             "no-undef": "error",
             "semi": "warn"
-        }  
+        }
     }
 ];
 ```
@@ -286,11 +286,11 @@ export default [
         files: ["**/*.js"],
         plugins: {
             jsdoc
-        }
+        },
         rules: {
             "jsdoc/require-description": "error",
             "jsdoc/check-values": "error"
-        }  
+        }
     }
 ];
 ```
@@ -311,11 +311,11 @@ export default [
         files: ["**/*.js"],
         plugins: {
             jsd: jsdoc
-        }
+        },
         rules: {
             "jsd/require-description": "error",
             "jsd/check-values": "error"
-        }  
+        }
     }
 ];
 ```
@@ -340,10 +340,10 @@ export default [
                     myrule
                 }
             }
-        }
+        },
         rules: {
             "custom/myrule": "error"
-        }  
+        }
     }
 ];
 ```
@@ -406,16 +406,18 @@ export default [
 
 ### Using predefined configs
 
-ESLint has two predefined configs:
+ESLint has two predefined configurations for JavaScript:
 
-* `eslint:recommended` - enables the rules that ESLint recommends everyone use to avoid potential errors
-* `eslint:all` - enables all of the rules shipped with ESLint
+* `js.configs.recommended` - enables the rules that ESLint recommends everyone use to avoid potential errors
+* `js.configs.all` - enables all of the rules shipped with ESLint
 
-To include these predefined configs, you can insert the string values into the exported array and then make any modifications to other properties in subsequent configuration objects:
+To include these predefined configurations, install the `@eslint/js` package and then make any modifications to other properties in subsequent configuration objects:
 
 ```js
+import js from "@eslint/js";
+
 export default [
-    "eslint:recommended",
+    js.configs.recommended,
     {
         rules: {
             semi: ["warn", "always"]


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
The purpose is to update the [2022 FlatConfig announcement](https://eslint.org/blog/2022/08/new-config-system-part-2/#using-predefined-configs
) according to the [latest breaking changes](https://github.com/eslint/eslint/issues/17488) because Google still shows this page in search results.

#### What changes did you make? (Give an overview)
Aligned the blogpost with the [latest docs](https://eslint.org/docs/latest/use/configure/configuration-files#using-predefined-configurations).

#### Related Issues
https://github.com/eslint/eslint/issues/17488

#### Is there anything you'd like reviewers to focus on?
have a good day
