### PR TITLE
chore: Add flex-wrap property for responsive layout on homepage

### DIFF
--- a/src/assets/scss/foundations.scss
+++ b/src/assets/scss/foundations.scss
@@ -114,6 +114,10 @@ main {
     max-width: 1280px;
     margin: 0 auto;
     padding: var(--space-xl-3xl) calc(1rem + 1vw);
+
+    @media screen and (min-width: 1920px) {
+        max-width: 60%;
+    }
 }
 
 .section-head {

--- a/src/assets/scss/homepage.scss
+++ b/src/assets/scss/homepage.scss
@@ -173,7 +173,6 @@
     @media all and (min-width: 768px) {
         display: flex;
         justify-content: space-evenly;
-        flex-wrap: wrap;
     }
 }
 

--- a/src/assets/scss/homepage.scss
+++ b/src/assets/scss/homepage.scss
@@ -173,6 +173,7 @@
     @media all and (min-width: 768px) {
         display: flex;
         justify-content: space-evenly;
+        flex-wrap: wrap;
     }
 }
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
Handle responsive layout of metrics in home page on ultra wide monitors/views.

#### What changes did you make? (Give an overview)

Basically adding a flex wrap property to handle in the case of step-6 font being too large on ultra wide views which causes the text to get out of its parent frames.

here's a before and after screenshots

ultra wide:
![image](https://github.com/eslint/eslint.org/assets/49820024/de3d1905-d622-4cb4-be3a-b2927aaa8759)
![image](https://github.com/eslint/eslint.org/assets/49820024/547adf31-76de-48a7-8e9a-0516fd43deaf)

wide:
![image](https://github.com/eslint/eslint.org/assets/49820024/27c67929-789f-4cf4-a699-9c2d140b0ede)
![image](https://github.com/eslint/eslint.org/assets/49820024/154e839a-33ca-425a-8e90-bec2f64e7bf4)

normal:
![image](https://github.com/eslint/eslint.org/assets/49820024/6f8ae129-7134-4732-a079-84fce5be5720)
![image](https://github.com/eslint/eslint.org/assets/49820024/7b473938-5701-422f-98f8-9212df0958ac)

extra small/mobile:
![image](https://github.com/eslint/eslint.org/assets/49820024/98affbe1-f734-4a60-9f3d-4d4704a32849)
![image](https://github.com/eslint/eslint.org/assets/49820024/402d9d04-08bd-44e5-8b37-caf86a0cc5db)


