### PR TITLE
fix: disable font ligatures in code blocks for better readability

### DIFF
--- a/src/assets/scss/foundations.scss
+++ b/src/assets/scss/foundations.scss
@@ -161,6 +161,7 @@ hr {
 code,
 pre {
     font-family: var(--mono-font);
+    font-variant-ligatures: none;
 }
 
 code {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

- Fix #577 

#### What changes did you make? (Give an overview)


- Set [font-variant-ligatures](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures) to `none`.
- Same as [docs website](https://github.com/eslint/eslint/blob/b2d256c7356838f908c4a5762d6dc64b41bbce5d/docs/src/assets/scss/foundations.scss#L164)

#### Before

<img width="686" alt="Screenshot 2024-06-13 at 8 13 09 AM" src="https://github.com/eslint/eslint.org/assets/46647141/cd815d0e-86cb-4143-b532-dd6235d06ce3">

#### After

<img width="744" alt="Screenshot 2024-06-13 at 8 12 38 AM" src="https://github.com/eslint/eslint.org/assets/46647141/cae68706-9a9a-426b-9f12-de46fa9a6b9c">




#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
