### PR TITLE
chore: switch to eslint-config-eslint v11

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,7 +18,7 @@ const slugify = require("slugify");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
 const Image = require("@11ty/eleventy-img");
-const path = require("path");
+const path = require("node:path");
 const yaml = require("js-yaml");
 const { DateTime } = require("luxon");
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 
 const eslintConfigESLintBase = require("eslint-config-eslint/base");
 const eslintConfigESLintCJS = require("eslint-config-eslint/cjs");
+const eslintConfigESLintFormatting = require("eslint-config-eslint/formatting");
 const globals = require("globals");
 const reactPlugin = require("eslint-plugin-react");
 const reactRecommended = require("eslint-plugin-react/configs/recommended");
@@ -20,6 +21,8 @@ module.exports = [
             "src/_11ty/**"
         ]
     },
+
+    eslintConfigESLintFormatting,
 
     ...eslintConfigESLintCJS.map(config => ({
         ...config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,8 @@
                 "eleventy-plugin-nesting-toc": "^1.3.0",
                 "eleventy-plugin-page-assets": "^0.3.0",
                 "eleventy-plugin-reading-time": "^0.0.1",
-                "eslint": "^9.2.0",
-                "eslint-config-eslint": "^10.0.0",
+                "eslint": "^9.5.0",
+                "eslint-config-eslint": "^11.0.0",
                 "eslint-plugin-jsx-a11y": "^6.8.0",
                 "eslint-plugin-react": "^7.34.1",
                 "eslint-plugin-react-hooks": "^4.6.2",
@@ -2793,10 +2793,24 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/config-array": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.16.0.tgz",
+            "integrity": "sha512-/jmuSd74i4Czf1XXn7wGRWZCuyaUZ330NH1Bek0Pplatt4Sy1S5haN21SCLLdbeKslQ+S0wEJ+++v5YibSi+Lg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.4",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.0.2.tgz",
-            "integrity": "sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+            "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -2847,9 +2861,18 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.2.0.tgz",
-            "integrity": "sha512-ESiIudvhoYni+MdsI8oD7skpprZ89qKocwRM2KEvhhBJ9nl5MRh7BXU5GTod7Mdygq+AUl+QzId6iWJKR/wABA==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.5.0.tgz",
+            "integrity": "sha512-A7+AOT2ICkodvtsWnxZP4Xxk3NbZ3VMHd8oihydLRGrJgqqdEz1qSeEgXYyT/Cu8h1TWWsQRejIx48mtjZ5y1w==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2921,20 +2944,6 @@
                 "@hapi/hoek": "^8.3.0"
             }
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-            "dev": true,
-            "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.3",
-                "debug": "^4.3.1",
-                "minimatch": "^3.0.5"
-            },
-            "engines": {
-                "node": ">=10.10.0"
-            }
-        },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -2948,16 +2957,10 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-            "dev": true
-        },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.2.4.tgz",
-            "integrity": "sha512-Ttl/jHpxfS3st5sxwICYfk4pOH0WrLI1SpW283GgQL7sCWU7EHIOhX4b4fkIxr3tkfzwg8+FNojtzsIEE7Ecgg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+            "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
             "dev": true,
             "engines": {
                 "node": ">=18.18"
@@ -7850,18 +7853,18 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.2.0.tgz",
-            "integrity": "sha512-0n/I88vZpCOzO+PQpt0lbsqmn9AsnsJAQseIqhZFI8ibQT0U1AkEKRxA3EVMos0BoHSXDQvCXY25TUjB5tr8Og==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.5.0.tgz",
+            "integrity": "sha512-+NAOZFrW/jFTS3dASCGBxX1pkFD0/fsO+hfAkJ4TyYKwgsXZbqzrw+seCYFCcPCYXvnD67tAnglU7GQTz6kcVw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^3.0.2",
-                "@eslint/js": "9.2.0",
-                "@humanwhocodes/config-array": "^0.13.0",
+                "@eslint/config-array": "^0.16.0",
+                "@eslint/eslintrc": "^3.1.0",
+                "@eslint/js": "9.5.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.2.3",
+                "@humanwhocodes/retry": "^0.3.0",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
@@ -7871,7 +7874,7 @@
                 "eslint-scope": "^8.0.1",
                 "eslint-visitor-keys": "^4.0.0",
                 "espree": "^10.0.1",
-                "esquery": "^1.4.2",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^8.0.0",
@@ -7897,7 +7900,7 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/eslint-compat-utils": {
@@ -7916,9 +7919,9 @@
             }
         },
         "node_modules/eslint-config-eslint": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-10.0.0.tgz",
-            "integrity": "sha512-ejGeXkQLyAEqUBr6UE246sZBRqscQVuJOTuYLYIt+GaCrfRodLsoJ6/oXRHZumcLDbZYnZoXRpgYy8+NJ/UOOw==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-eslint/-/eslint-config-eslint-11.0.0.tgz",
+            "integrity": "sha512-AWmzAfDUUaHYZzGQguHXzh/PkKHfrwttXIglqE0xWSkJDRhionaJVT1+niI1qKYRPn/FE5CHQIZ24L1u5rYSaw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
         "eleventy-plugin-nesting-toc": "^1.3.0",
         "eleventy-plugin-page-assets": "^0.3.0",
         "eleventy-plugin-reading-time": "^0.0.1",
-        "eslint": "^9.2.0",
-        "eslint-config-eslint": "^10.0.0",
+        "eslint": "^9.5.0",
+        "eslint-config-eslint": "^11.0.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -102,7 +102,7 @@
         "yorkie": "^2.0.0"
     },
     "overrides": {
-        "eslint": "^9.2.0"
+        "eslint": "^9.5.0"
     },
     "dependencies": {
         "@codemirror/highlight": "0.19.7",

--- a/tools/add-author.js
+++ b/tools/add-author.js
@@ -12,9 +12,9 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const fs = require("fs/promises");
+const fs = require("node:fs/promises");
 const { Octokit } = require("@octokit/rest");
-const path = require("path");
+const path = require("node:path");
 
 //-----------------------------------------------------------------------------
 // Data

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -17,7 +17,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const fs = require("fs/promises");
+const fs = require("node:fs/promises");
 const { request } = require("undici");
 const { graphql: githubGraphQL } = require("@octokit/graphql");
 

--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -13,9 +13,9 @@ const semver = require("semver");
 const cheerio = require("cheerio");
 const { request } = require("undici");
 const { graphql } = require("@octokit/graphql");
-const fs = require("fs/promises");
+const fs = require("node:fs/promises");
 const { DateTime } = require("luxon");
-const util = require("util");
+const util = require("node:util");
 const downloadStats = require("download-stats");
 const { upcomingVersionPrereleaseType } = require("./release-data");
 

--- a/tools/fetch-team-data.js
+++ b/tools/fetch-team-data.js
@@ -12,10 +12,10 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const fs = require("fs/promises");
+const fs = require("node:fs/promises");
 const matter = require("gray-matter");
 const { Octokit } = require("@octokit/rest");
-const path = require("path");
+const path = require("node:path");
 
 //-----------------------------------------------------------------------------
 // Data

--- a/tools/validate-links.js
+++ b/tools/validate-links.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const path = require("path");
+const path = require("node:path");
 const TapRender = require("@munter/tap-render");
 const spot = require("tap-spot");
 const hyperlink = require("hyperlink");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const path = require("path");
+const path = require("node:path");
 const webpack = require("webpack");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

Switches to eslint-config-eslint v11 & eslint v9.5.0 for linting this repo.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated dependencies, updated eslint config accordingly, and updated tools, scripts and config files to use `node:` protocol.

#### Related Issues

https://github.com/eslint/eslint/pull/18560

https://github.com/eslint/eslint/pull/18434

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
