### PR TITLE
fix: Make dark scroll bar in dark theme for Chromium-based browsers

### DIFF
--- a/src/assets/scss/tokens/themes.scss
+++ b/src/assets/scss/tokens/themes.scss
@@ -161,6 +161,8 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
+	color-scheme: dark;
+
 	--body-background-color: var(--color-neutral-900);
 	--body-text-color: var(--color-neutral-300);
 	--headings-color: #fff;


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Make a dark scroll bar in a dark theme for Chromium-based browsers.

#### What changes did you make? (Give an overview)

<details><summary>Before:</summary>

![image](https://github.com/eslint/eslint.org/assets/19418601/7f273c2f-ddb3-4c07-81d5-009930a38e8f)

</details>

<details><summary>After:</summary>

![image](https://github.com/eslint/eslint.org/assets/19418601/cd8342b9-ecb7-4339-b03d-0da396733411)

</details>

#### Related Issues

Same as https://github.com/eslint/eslint/pull/17753.

#### Is there anything you'd like reviewers to focus on?

In the OS settings, enable the display of the scroll bar Always if you use a touchpad.

<!-- markdownlint-disable-file MD004 -->
