### PR TITLE
fix:  fix search input stylings

### DIFF
--- a/src/assets/scss/components/search.scss
+++ b/src/assets/scss/components/search.scss
@@ -25,10 +25,10 @@
 	color: var(--body-text-color);
 	position: absolute;
 	display: flex;
-	top: 50%;
-	offset-block-start: 50%;
-	transform: translateY(-50%);
-	right: 1.5rem;
+	top: 25%;
+	offset-block-start: 25%;
+	transform: translateY(-25%);
+	right: 1rem;
 	offset-inline-end: 1.5rem;
 	z-index: 3;
 	padding: 0;
@@ -45,6 +45,8 @@
 .search__input {
 	padding-left: 2.5rem;
 	padding-inline-start: 2.5rem;
+	padding-right: 2.5rem;
+	padding-inline-end: 2.5rem;
 	outline-offset: 1px;
 	width: 100%;
 }
@@ -95,14 +97,14 @@
 	border-radius: 0 0 var(--border-radius) var(--border-radius);
 	border: 1px solid var(--divider-color);
 	position: relative;
-	top: 0.25rem;
+	top: -1.5rem;
 	max-height: 400px;
 	overflow-y: auto;
 
 	@media all and (min-width: 1023px) {
 		box-shadow: var(--shadow-lg);
 		position: absolute;
-		top: calc(100% + 0.25rem);
+		top: calc(100% - 1.5rem);
 	}
 
 	&[data-results="true"] {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Changes made:

1. Fixed the search text overlapping with the close icon
2. Correct the position of the close icon
3. Adjusted the positioning of the search results dropdown

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/3fec793d-eef4-41ae-afdb-686f2408bb23) |  ![image](https://github.com/user-attachments/assets/8236a1ae-d660-4581-b4c3-ccee133dd717)  |

similar to https://github.com/eslint/eslint/pull/18682
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
