### PR TITLE
fix: page number in blog's url

### DIFF
--- a/src/content/pages/blog.html
+++ b/src/content/pages/blog.html
@@ -1,7 +1,7 @@
 ---
 layout: blog.html
 hook: "blog_page"
-permalink: 'blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber }}{% endif %}/index.html'
+permalink: 'blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber + 1 }}{% endif %}/index.html'
 
 pagination:
     alias: blogPosts


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
the page number in the url of blog pages (not category wise blog pages) is one less than its original page number

![Screenshot 2024-08-02 153143](https://github.com/user-attachments/assets/1043f4e7-9cb5-4b52-bee0-75a74fe31efd)

blog has total 45 pages if we head over to the last page through url then it take us to error page.
![Screenshot 2024-08-02 154918](https://github.com/user-attachments/assets/ce341ac4-8f92-4ac0-a1f4-3c18f9ec6612)
<!--

    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
change the permalink of blog pages by increasing the count by one.
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
