### PR TITLE
feat: [playground] Add revert configs to default option

### DIFF
--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -324,3 +324,9 @@ ul.config__added-rules {
 		border-color: var(--color-rose-700);
 	}
 }
+
+.playground__config__revertConfig-btn {
+	background-color: var(--secondary-button-background-color);
+	color: var(--secondary-button-text-color);
+	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.1);
+}

--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -1,5 +1,5 @@
 .playground__config__download-btn {
-	margin: 1rem 0;
+	margin: 1rem 0.5rem 1rem 0;
 }
 
 [data-config-section] {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -334,6 +334,9 @@ const App = () => {
 						data-open={isConfigHidden ? true : showConfigMenu}
 					>
 						<Configuration
+							initialOptions={fillOptionsDefaults(
+								getDefaultOptions(),
+							)}
 							ruleNames={ruleNames}
 							options={options}
 							onUpdate={updateOptions}

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -102,6 +102,7 @@ const defaultOption = {
 const isEmpty = obj => Object.keys(obj).length === 0;
 
 export default function Configuration({
+	initialOptions,
 	rulesMeta,
 	eslintVersion,
 	onUpdate,
@@ -204,6 +205,10 @@ export default function Configuration({
 		onUpdate(Object.assign({}, options));
 	};
 
+	const revertToDefault = () => {
+		onUpdate(Object.assign({}, initialOptions));
+	};
+
 	// Remove empty objects from download configuration
 	const hasEcmaFeatures = !isEmpty(
 		options.languageOptions.parserOptions.ecmaFeatures,
@@ -268,11 +273,11 @@ export default function Configuration({
 									isSearchable={false}
 									styles={customStyles}
 									theme={theme => customTheme(theme)}
-									defaultValue={ECMAVersionsOptions.filter(
+									value={ECMAVersionsOptions.filter(
 										ecmaVersion =>
 											ecmaVersion.value ===
 											(options.languageOptions
-												.ecmaVersion || "default"),
+												?.ecmaVersion || "default"),
 									)}
 									options={ECMAVersionsOptions}
 									onChange={selected => {
@@ -295,10 +300,10 @@ export default function Configuration({
 								isSearchable={false}
 								styles={customStyles}
 								theme={theme => customTheme(theme)}
-								defaultValue={sourceTypeOptions.filter(
+								value={sourceTypeOptions.filter(
 									sourceTypeOption =>
 										sourceTypeOption.value ===
-										(options.languageOptions.sourceType ||
+										(options.languageOptions?.sourceType ||
 											"default"),
 								)}
 								options={sourceTypeOptions}
@@ -326,7 +331,7 @@ export default function Configuration({
 							<Select
 								isClearable
 								isMulti
-								defaultValue={ECMAFeaturesOptions.filter(
+								value={ECMAFeaturesOptions.filter(
 									ecmaFeatureName =>
 										options.languageOptions.parserOptions
 											.ecmaFeatures[
@@ -610,6 +615,13 @@ export default function Configuration({
 					>
 						Download this config file
 					</a>
+
+					<button
+						onClick={revertToDefault}
+						className="c-btn playground__config__revertConfig-btn"
+					>
+						Revert Configs to Default
+					</button>
 				</div>
 			</div>
 		</div>

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -620,7 +620,7 @@ export default function Configuration({
 						onClick={revertToDefault}
 						className="c-btn playground__config__revertConfig-btn"
 					>
-						Revert Configs to Default
+						Reset
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

A "Reset" button has been added to restore the config to the default ESLint settings, matching what users see when they first open the playground.

![image](https://github.com/user-attachments/assets/f167b248-8ad3-4908-9b0e-0ebd735bc808)

#### Related Issues
#592 

#### Is there anything you'd like reviewers to focus on?
The button is currently labelled "Revert Configs to Default," but I'm open to suggestions for a different name also.
<!-- markdownlint-disable-file MD004 -->
