### PR TITLE
fix: make algolia link not reachable via tab key

### DIFF
--- a/src/_includes/components/search.html
+++ b/src/_includes/components/search.html
@@ -9,7 +9,7 @@
         <p class="visually-hidden" id="search-hint">{{ site.blog_page.search.hint }}</p>
         <div class="search__inner-input-wrapper">
             <input type="search" id="search" class="search__input" autocomplete="off" aria-describedby="search-hint" pattern="\S+">
-            <a class="search_powered-by-wrapper"  href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer">
+            <a class="search_powered-by-wrapper" tabindex="-1" href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer">
                 <div class="search__powered-by">
                     <span class="powered-by-text">Powered by</span>
                     <svg width="77" height="19" aria-label="Algolia" role="img" id="Layer_1" xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

When searching with the search box, say I input `mjs` and press `<Tab>` key, it would focus firstly on the link of algolia which  is covered by the search result modal, then the clear button, then the result item. IMO it makes more sense to disable it from reachable via tab key.

![Screenshot-r7HoVxar@2x](https://github.com/user-attachments/assets/3355487f-76ea-436c-bd79-b5feacf32306)


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Add `tabindex="-1"` to `<a />` element.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
