### PR TITLE
Revert "fix: make algolia link not reachable via tab key"

### DIFF
--- a/src/_includes/components/search.html
+++ b/src/_includes/components/search.html
@@ -9,7 +9,7 @@
         <p class="visually-hidden" id="search-hint">{{ site.blog_page.search.hint }}</p>
         <div class="search__inner-input-wrapper">
             <input type="search" id="search" class="search__input" autocomplete="off" aria-describedby="search-hint" pattern="\S+">
-            <a class="search_powered-by-wrapper" tabindex="-1" href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer">
+            <a class="search_powered-by-wrapper"  href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer">
                 <div class="search__powered-by">
                     <span class="powered-by-text">Powered by</span>
                     <svg width="77" height="19" aria-label="Algolia" role="img" id="Layer_1" xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Links should be accessible via tab. We shouldn't eliminate that. We need a different approach to solve the original problem.

Reverts eslint/eslint.org#615