### PR TITLE
fix: Ensure donations don't show up as sponsors

### DIFF
--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -34,6 +34,8 @@ const knownOneTimers = new Set([
 	"GitHub Sponsors",
 	"Read the Docs",
 	"BuySellAds",
+	"EthicalAds",
+	"Threadless",
 ]);
 
 // we must have a token for this to work
@@ -395,7 +397,7 @@ async function fetchGitHubSponsors() {
 	const donations = openCollectiveDonations.concat(githubDonations);
 
 	// sort donations so most recent is first
-	donations.sort((a, b) => new Date(a) - new Date(b));
+	donations.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
 
 	// simplified data structure
 	const tierSponsors = {

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -223,6 +223,7 @@ async function fetchGitHubSponsors() {
                             },
                             tier {
                                 monthlyPriceInDollars
+                                isOneTime
                             }
                         }
                         pageInfo {
@@ -329,16 +330,23 @@ async function fetchGitHubSponsors() {
 		);
 	}
 
-	// return an array in the same format as Open Collective
-	const sponsors = sponsorships.map(({ sponsor, tier }) => ({
-		name: sponsor.name || sponsor.login,
-		image: sponsor.avatarUrl,
-		url: fixUrl(sponsor.websiteUrl || sponsor.url),
-		monthlyDonation: tier.monthlyPriceInDollars,
-		source: "github",
-		tier: getTierSlug(tier.monthlyPriceInDollars),
-	}));
+	// process sponsorships
+	const sponsors = sponsorships
 
+		// filter out one-time sponsorships -- these are displayed in the donations list
+		.filter(({ tier }) => !tier.isOneTime)
+
+		// return an array in the same format as Open Collective
+		.map(({ sponsor, tier }) => ({
+			name: sponsor.name || sponsor.login,
+			image: sponsor.avatarUrl,
+			url: fixUrl(sponsor.websiteUrl || sponsor.url),
+			monthlyDonation: tier.monthlyPriceInDollars,
+			source: "github",
+			tier: getTierSlug(tier.monthlyPriceInDollars),
+		}));
+
+	// process one-time donations
 	const donations = donationsResponse.organization.sponsorsActivities.nodes
 		.filter(transaction => transaction.tier && transaction.tier.isOneTime)
 		.map(({ sponsor, timestamp, tier, id }) => ({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Siemens recently donated $1000 to ESLint through GitHub Sponsors, but it's showing up as a sponsor rather than a donation. 

This updates our script to filter out any one-time sponsorships from the sponsors list (these are displayed as individual donations rather than sponsorships).

I also fixed the sorting of donations so that the Open Collective and GitHub donations are sorted in chronological order across both data sets. 

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
