### PR TITLE
fix: Don't deploy future blog posts in production

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -106,4 +106,10 @@ module.exports = [
 			],
 		},
 	},
+	{
+		files: [".eleventy.js"],
+		rules: {
+			"no-console": "off",
+		},
+	},
 ];

--- a/src/_11ty/collections/blogposts.js
+++ b/src/_11ty/collections/blogposts.js
@@ -1,12 +1,10 @@
-const { DateTime } = require("luxon");
-
 module.exports = collection => {
 	let now = new Date();
 	const CONTEXT = process.env.CONTEXT;
-	const showFuturePostsAndDrafts = !CONTEXT || CONTEXT === "deploy-preview";
+	const showDrafts = !CONTEXT || CONTEXT === "deploy-preview";
 
 	// for local development and deploy previews, show drafts
-	const drafts = showFuturePostsAndDrafts
+	const drafts = showDrafts
 		? collection
 				.getFilteredByGlob("./src/content/drafts/*.md")
 				.filter(item => !item.inputPath.includes("README.md"))
@@ -16,10 +14,7 @@ module.exports = collection => {
 		collection
 			.getFilteredByGlob("./src/content/blog/*.md")
 			.filter(item => {
-				return (
-					showFuturePostsAndDrafts ||
-					(!item.data.draft && item.date <= now)
-				);
+				return showDrafts || !item.data.draft;
 			})
 			.reverse(),
 	);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

A future blog post is a blog post with a publication date > current date. Those posts shouldn't appear on the site before their publication date.

Currently, if we have a future blog post merged, it indeed wouldn't appear in the list of blog posts on https://eslint.org/blog/. But it's still rendered, deployed, can be accessed, and appears in the sitemap and in the list of blog posts on its category page (e.g., https://eslint.org/blog/category/case-studies/).

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `.eleventy.js` to completely ignore future blog posts, so they won't be rendered and deployed.

#### Related Issues

https://github.com/eslint/eslint.org/pull/645#issuecomment-2390639224

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
