### PR TITLE
fix: Display and calculation of sponsors

### DIFF
--- a/src/_data/sponsors.json
+++ b/src/_data/sponsors.json
@@ -142,7 +142,7 @@
             "monthlyDonation": 350,
             "totalDonations": 19964,
             "source": "opencollective",
-            "tier": null
+            "tier": "bronze-sponsor"
         },
         {
             "name": "Principal Financial Group",

--- a/src/_data/sponsors.json
+++ b/src/_data/sponsors.json
@@ -74,6 +74,15 @@
     ],
     "bronze": [
         {
+            "name": "Cybozu",
+            "url": "https://cybozu.co.jp/",
+            "image": "https://images.opencollective.com/cybozu/933e46d/logo.png",
+            "monthlyDonation": 350,
+            "totalDonations": 19964,
+            "source": "opencollective",
+            "tier": "bronze-sponsor"
+        },
+        {
             "name": "WordHint",
             "url": "https://www.wordhint.net/",
             "image": "https://images.opencollective.com/wordhint/be86813/avatar.png",
@@ -135,15 +144,6 @@
         }
     ],
     "backers": [
-        {
-            "name": "Cybozu",
-            "url": "https://cybozu.co.jp/",
-            "image": "https://images.opencollective.com/cybozu/933e46d/logo.png",
-            "monthlyDonation": 350,
-            "totalDonations": 19964,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
-        },
         {
             "name": "Principal Financial Group",
             "url": "https://www.principal.com/about-us",

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -222,11 +222,12 @@ hook: "sponsors_page"
         </div>
         <div class="grid">
             <ul role="list" class="sponsors span-1-12 sponsors--backers">
+                {% set fallback_image = '/assets/images/people/_placeholder-avatar.svg' %}
                 {% for sponsor in sponsors.backers %}
                 <li>
                     <a href="{{ sponsor.url | url }}" class="sponsor-link" rel="nofollow noopener sponsored" target="_blank">
-                        <img loading="lazy" decoding="async" src="{{ sponsor.image }}" height="48" width="48"
-                            onerror="this.src = '/assets/images/people/_placeholder-avatar.svg'"
+                        <img loading="lazy" decoding="async" src="{{ sponsor.image if sponsor.image else fallback_image }}" height="48" width="48"
+                            onerror="this.src = '{{fallback_image}}'"
                             alt="{{ sponsor.name if sponsor.name else "Anonymous" }} is donating {{ sponsor.monthlyDonation | dollars }} each month"
                             title="{{ sponsor.name if sponsor.name else "Anonymous" }} is donating {{ sponsor.monthlyDonation | dollars }} each month" />
                     </a>

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -182,7 +182,7 @@ async function fetchOpenCollectiveData() {
 				: order.amount.value,
 		totalDonations: order.totalDonations.value,
 		source: "opencollective",
-		tier: order.tier ? order.tier.slug : null,
+		tier: order.tier ? order.tier.slug : getTierSlug(order.amount.value),
 	}));
 
 	const donations = payload.data.donations.nodes


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Fix sponsors display

#### What changes did you make? (Give an overview)

1. Ensure that sponsors with `null` names and images are still displayed on the sponsors page
2. Ensure that sponsors who give enough money each month are properly credited in the correct tier (Cybozu was incorrectly not displayed as a bronze sponsor -- this was due to an error in `fetch-sponsors`)

The first issue was causing the website build to fail.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
