### PR TITLE
fix: use higher contrast color tokens for code comments

### DIFF
--- a/src/assets/scss/syntax-highlighter.scss
+++ b/src/assets/scss/syntax-highlighter.scss
@@ -52,10 +52,10 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #6e7f8e;
+	color: var(--color-neutral-500);
 
 	[data-theme="dark"] & {
-		color: #8e9fae;
+		color: var(--color-neutral-400);
 	}
 }
 

--- a/src/assets/scss/syntax-highlighter.scss
+++ b/src/assets/scss/syntax-highlighter.scss
@@ -52,11 +52,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: var(--color-neutral-500);
-
-	[data-theme="dark"] & {
-		color: var(--color-neutral-400);
-	}
+	color: var(--code-comments-color);
 }
 
 .token.namespace {

--- a/src/assets/scss/tokens/themes.scss
+++ b/src/assets/scss/tokens/themes.scss
@@ -74,6 +74,7 @@
 	--color-brand: var(--color-primary-800);
 	--body-background-color: #fff;
 	--body-text-color: var(--color-neutral-500);
+	--code-comments-color: var(--color-neutral-500);
 	--headings-color: var(--color-neutral-900);
 
 	--border-color: var(--color-neutral-300);
@@ -112,6 +113,7 @@
 	:root {
 		--body-background-color: var(--color-neutral-900);
 		--body-text-color: var(--color-neutral-300);
+		--code-comments-color: var(--color-neutral-400);
 		--headings-color: #fff;
 
 		--divider-color: var(--color-neutral-600);
@@ -149,6 +151,7 @@
 html[data-theme="light"] {
 	--body-background-color: #fff;
 	--body-text-color: var(--color-neutral-500);
+	--code-comments-color: var(--color-neutral-500);
 	--headings-color: var(--color-neutral-900);
 
 	--border-color: var(--color-neutral-300);
@@ -185,6 +188,7 @@ html[data-theme="dark"] {
 
 	--body-background-color: var(--color-neutral-900);
 	--body-text-color: var(--color-neutral-300);
+	--code-comments-color: var(--color-neutral-400);
 	--headings-color: #fff;
 
 	--divider-color: var(--color-neutral-600);


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Improve color contrast in code comments to WCAG AA levels.

#### What changes did you make? (Give an overview)

I swapped out the hardcoded comment colors with the closest theme tokens that had sufficient contrast.

<table>
<thead>
<tr>
<th>Mode
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Light</td>
<td><img alt="'Before' screenshot in light mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/ecc3e6a9-7f25-4a8e-bf7b-4fa0c355c3c4" width="315px" /></td>
<td><img alt="'After' screenshot in light mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/0a77ad15-ef3a-49a3-8a19-f824d00dccfe" width="315px" /></td>
</tr>
<tr>
<td>Dark</td>
<td><img alt="'Before' screenshot in dark mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/ef1809b4-bdc4-4008-bea6-76e83f8f04a8" width="315px" /></td>
<td><img alt="'After' screenshot in dark mode of a code block with just barely enough contrast for code comments" src="https://github.com/user-attachments/assets/bf93e859-b51a-416d-bcb9-35d925c52616" width="315px" /></td>
</tr>
</tbody>
</table>

#### Related Issues

Fixes #665. Corresponds to https://github.com/eslint/eslint/pull/19187.

#### Is there anything you'd like reviewers to focus on?

If there are other ad-hoc colors just barely off from color tokens, I'd be happy to clean those up in a followup?

<!-- markdownlint-disable-file MD004 -->
