### PR TITLE
fix: Overflow Issue by Adjusting Social Icon Spacing

### DIFF
--- a/src/assets/scss/components/social-icons.scss
+++ b/src/assets/scss/components/social-icons.scss
@@ -21,5 +21,9 @@
 		@media screen and (min-width: 1022px) and (max-width: 1200px) {
 			gap: 1.5rem;
 		}
+
+		@media screen and (min-width: 800px) and (max-width: 880px) {
+			gap: 1.25rem;
+		}
 	}
 }

--- a/src/assets/scss/components/social-icons.scss
+++ b/src/assets/scss/components/social-icons.scss
@@ -17,5 +17,9 @@
 				display: flex;
 			}
 		}
+
+		@media screen and (min-width: 1022px) and (max-width: 1200px) {
+			gap: 1.5rem;
+		}
 	}
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->
The social icons overflow the screen, causing an unwanted scrollbar to appear.
<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

 I've reduced the gap between the icons on specific screen sizes to resolve this.

| Before | After |
--------|---------
|  ![image](https://github.com/user-attachments/assets/093b1701-ae13-4f29-bc94-ac6c15661ae5)  |  ![image](https://github.com/user-attachments/assets/c96f19c5-0de0-405f-a274-9717fbde2690)  |
|  ![image](https://github.com/user-attachments/assets/78a270c5-4dea-444f-a856-842a60e0e4c7)  |  ![image](https://github.com/user-attachments/assets/d5f4c43f-0153-4c20-833d-f6174d0a3a5a) |









#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
