### PR TITLE
chore: Fixing Focus Order by Rearranging Element Sequence

### DIFF
--- a/src/_includes/components/search.html
+++ b/src/_includes/components/search.html
@@ -9,7 +9,16 @@
         <p class="visually-hidden" id="search-hint">{{ site.blog_page.search.hint }}</p>
         <div class="search__inner-input-wrapper">
             <input type="search" id="search" class="search__input" autocomplete="off" aria-describedby="search-hint" pattern="\S+">
-            <a class="search_powered-by-wrapper"  href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral&amp;utm_content=powered_by&amp;utm_campaign=docsearch" target="_blank" rel="noopener noreferrer">
+            <div id="search-results" class="search-results"></div>
+            <button class="search__clear-btn" id="search__clear-btn" hidden>
+                <span class="visually-hidden">{{ site.blog_page.search.clear }}</span>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M9 3L3 9M3 3L9 9" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+            </button>
+            <a class="search_powered-by-wrapper"
+                href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral&amp;utm_content=powered_by&amp;utm_campaign=docsearch"
+                target="_blank" rel="noopener noreferrer">
                 <div class="search__powered-by">
                     <span class="powered-by-text">Powered by</span>
                     <svg width="77" height="19" aria-label="Algolia" role="img" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
@@ -42,14 +51,7 @@
                     </svg>
                 </div>
             </a>
-            <button class="search__clear-btn" id="search__clear-btn" hidden>
-                <span class="visually-hidden">{{ site.blog_page.search.clear }}</span>
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false">
-                    <path d="M9 3L3 9M3 3L9 9" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </button>
         </div>
     </div>
     <div id="search-results-announcement" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
-    <div id="search-results" class="search-results"></div>
 </div>

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -24,8 +24,15 @@ const resultsLiveRegion = document.querySelector(
 );
 const searchInput = document.querySelector("#search");
 const searchClearBtn = document.querySelector("#search__clear-btn");
+const poweredByLink = document.querySelector(".search_powered-by-wrapper");
 let activeIndex = -1;
 let searchQuery;
+
+if (poweredByLink) {
+	poweredByLink.addEventListener("focus", function () {
+		clearSearchResults();
+	});
+}
 
 //-----------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->
Fixing Focus Order by Rearranging Element Sequence. 

Ref: https://github.com/eslint/eslint.org/pull/615#issuecomment-2299003407
<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

**Before:** When using the search box, pressing the `Tab` key would first focus on the Algolia link (which was covered by the search result modal), then on the clear button, and finally on the result items.

**After:** When using the search box, pressing the `Tab` key now first focuses on the search results, followed by the close button, and then the Algolia link.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
