### PR TITLE
feat: reduced hero vertical padding

### DIFF
--- a/src/assets/scss/components/hero.scss
+++ b/src/assets/scss/components/hero.scss
@@ -24,17 +24,16 @@
 	background-color: var(--hero-background-color);
 
 	@media all and (min-width: 800px) {
-		// when the ad is displayed
-		min-height: calc(285px + var(--space-xl-4xl));
+		align-items: center;
+		display: flex;
+
+		// Just enough height to be be slightly taller than the ad
+		min-height: 335px;
 	}
 
 	.content-container {
-		padding: var(--space-xl-4xl) 0 var(--space-l);
+		padding: var(--space-xl-2xl) 0 var(--space-l);
 		margin: 0;
-
-		@media all and (min-width: 800px) {
-			padding: var(--space-xl-4xl) 0 var(--space-xl-2xl);
-		}
 	}
 
 	> .content-container {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Reduce the vertical size of the "hero" to not grow in space with viewport height.

#### What changes did you make? (Give an overview)

* In larger viewports that have ads, shrinks the `min-height` of the `.hero` container to be just slightly more than the size of the ad
* In smaller viewports that don't have ads, reduces padding of its child `.content-container`

#### Related Issues

Fixes #671.

#### Is there anything you'd like reviewers to focus on?

There wasn't any existing calculation I could find to reuse for ad height. So I just went off the computed height locally.

<!-- markdownlint-disable-file MD004 -->
