### PR TITLE
feat: add option for custom release dates

### DIFF
--- a/src/_data/stats.json
+++ b/src/_data/stats.json
@@ -9,5 +9,5 @@
     "projectDependents": 23594482,
     "weeklyDownloads": 42269772,
     "nextVersion": "v9.18.0",
-    "nextVersionDate": "2024-12-27"
+    "nextVersionDate": "2025-01-10"
 }

--- a/tools/fetch-stats.js
+++ b/tools/fetch-stats.js
@@ -17,7 +17,10 @@ const fs = require("node:fs/promises");
 const { DateTime } = require("luxon");
 const util = require("node:util");
 const downloadStats = require("download-stats");
-const { upcomingVersionPrereleaseType } = require("./release-data");
+const {
+	upcomingVersionPrereleaseType,
+	nextVersionDateOverride,
+} = require("./release-data");
 
 //-----------------------------------------------------------------------------
 // Data
@@ -217,11 +220,16 @@ async function fetchGitHubNetworkStats() {
 	const baseDate = DateTime.fromISO("2024-01-12");
 	const currentVersionDate = DateTime.fromISO(stats.currentVersionDate);
 
-	stats.nextVersionDate = currentVersionDate
+	const nextVersionDate = currentVersionDate
 		.plus({
 			days: 14 - (currentVersionDate.diff(baseDate, "days").days % 14),
 		})
 		.toISODate();
+
+	stats.nextVersionDate =
+		nextVersionDateOverride && nextVersionDateOverride > nextVersionDate // string comparison works well with ISO format
+			? nextVersionDateOverride
+			: nextVersionDate;
 
 	await fs.writeFile(statsFilePath, JSON.stringify(stats, null, 4), {
 		encoding: "utf8",

--- a/tools/release-data.js
+++ b/tools/release-data.js
@@ -15,6 +15,19 @@
  */
 const upcomingVersionPrereleaseType = null;
 
+/**
+ * - Set to `null` if the next release date is per the regular schedule.
+ * - Set to the ISO 8601 string format of the next release date
+ *   if the next release date is not per the regular schedule.
+ *     Example: "2025-01-10"
+ *   This is typically used to skip a regularly scheduled release.
+ *   Note: Dates that are less than the date of the next regular release
+ *     are automatically ignored so that we don't need to update the stats manually.
+ * @type {null|string}
+ */
+const nextVersionDateOverride = "2025-01-10";
+
 module.exports = {
 	upcomingVersionPrereleaseType,
+	nextVersionDateOverride,
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Adds setting to hardcode next release date.

We've decided to skip the next scheduled release on 27 Dec, and updated `stats.json` in https://github.com/eslint/eslint.org/commit/c23f0005ac8508bc7c56251e33f66ab0a95b623f to reflect that. However,  `tools/fetch-stats.js` overwrites it (https://github.com/eslint/eslint.org/commit/7582067536a4aabf4e3f0f015fe9908e75c872c8) per its logic, so there needs to be a way to specify this in the data. 

#### What changes did you make? (Give an overview)

Updated `tools/fetch-stats.js` to use the new setting.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
