### PR TITLE
docs: update link in ESLint v9.18.0 release blog

### DIFF
--- a/src/content/blog/2025-01-10-eslint-v9.18.0-released.md
+++ b/src/content/blog/2025-01-10-eslint-v9.18.0-released.md
@@ -33,7 +33,7 @@ If you are upgrading from a previous version of ESLint, be sure to remove the `u
 
 Note that in order to use a TypeScript configuration file in Node.js, you still need to have [jiti](https://www.npmjs.com/package/jiti) installed in version 2.0 or higher.
 For Deno and Bun, no additional dependency is necessary.
-See the documentation about [TypeScript Configuration Files](https://eslint.org/docs/head/use/configure/configuration-files#typescript-configuration-files) for more information about this feature.
+See the documentation about [TypeScript Configuration Files](https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files) for more information about this feature.
 
 ### `no-shadow-restricted-names` checks imports and class names
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Switched a link to the website in the ESLint v9.18.0 release blog from `/head/` to `/latest/`. After updating the latest branch in eslint/eslint#19338 it's fine to link to the the latest version of the docs.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
