### PR TITLE
fix: improve WCAG 2.1 accessibility compliance

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -151,7 +151,8 @@
 </head>
 
 <body class="{{ hook | replace('_', '-') }}">
-    <div class="deprecation-notice">
+    <a href="#main" class="c-btn c-btn--primary" id="skip-link">{{ site.shared.skip_to_content }}</a>
+    <div class="deprecation-notice" role="alert">
         <svg class="hourglass-icon" fill="#ffffff" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink" width="15px" height="15px" viewBox="796 796 200 200"
             enable-background="new 796 796 200 200" xml:space="preserve">
@@ -170,7 +171,6 @@
         </svg>
         ESLint v8.x reached end-of-life on 2024-10-05 and is no longer maintained. <a href="/docs/latest/use/migrate-to-9.0.0"> Upgrade </a>
         or consider <a href="/version-support/"> long-term support options </a> </div>
-    <a href="#main" class="c-btn c-btn--primary" id="skip-link">{{ site.shared.skip_to_content }}</a>
 
     {{ content | safe }}
 

--- a/src/_includes/partials/faqs.html
+++ b/src/_includes/partials/faqs.html
@@ -1,4 +1,4 @@
-<section class="faqs section">
+<section class="faqs section" aria-labelledby="faqs-section-label">
     <div class="content-container grid">
         <div class="span-1-4">
             <h2 class="section-title" id="faqs-section-label">{{ site.donate_page.faq.title }}</h2>

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -304,7 +304,7 @@ eleventyExcludeFromCollections: true
 
 
 <section aria-labelledby="testimonials-section-label">
-    <h2 class="visually-hidden">{{ site.donate_page.testimonials.title }}</h2>
+    <h2 class="visually-hidden" id="testimonials-section-label">{{ site.donate_page.testimonials.title }}</h2>
     <div class="content-container">
         {% include 'components/testimonials-slider.html' %}
     </div>


### PR DESCRIPTION
#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
This pull request improves accessibility by addressing WCAG 2.1 issues, including adding `role="alert"` to the deprecation notice, moving the skip-to-content link to the top of the page to comply with WCAG 2.1 [2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html), correcting `aria-labelledby` on the FAQ section, and ensuring proper landmark usage across the page.

#### What changes did you make? (Give an overview)
- Added `role="alert"` to deprecation notice for better screen reader support.
- Moved "skip to content" link before deprecation notice for improved navigation.
- Updated FAQ section with proper `aria-labelledby` for better clarity.
- Fixed `testimonials-section-label` by aligning the ID with the heading element.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
