### PR TITLE
fix: add border after author's bio in blog

### DIFF
--- a/src/assets/scss/blog.scss
+++ b/src/assets/scss/blog.scss
@@ -56,8 +56,8 @@
 	grid-row: 1;
 
 	@media all and (max-width: 1023px) {
-		margin-top: 4rem;
-		margin-block-start: 4rem;
+		margin-top: 2rem;
+		margin-block-start: 2rem;
 	}
 }
 
@@ -124,6 +124,10 @@ ul.tag-list {
 	padding-block-start: var(--space-m);
 	margin-block-start: var(--space-m);
 	border-block-start: 1px solid var(--divider-color);
+
+	@media all and (max-width: 1023px) {
+		border-bottom: 1px solid var(--divider-color);
+	}
 }
 
 // https://github.com/eslint/eslint.org/issues/257


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Unlike pc screen size there is no border between author's bio and other info about blog in small screen size (below 1024px)
![Screenshot 2025-02-28 181432](https://github.com/user-attachments/assets/54a16c6f-1b14-45b5-90b2-205a113b1d3b)
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added the border here
![Screenshot 2025-02-28 181348](https://github.com/user-attachments/assets/f44c8e6e-35d4-4d9e-8dad-2523f5c662fd)


#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
