### PR TITLE
fix: search navigation on pressing Enter

### DIFF
--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -234,7 +234,8 @@ if (resultsElement) {
 			e.key !== "ArrowUp" &&
 			e.key !== "ArrowDown" &&
 			e.key !== "Tab" &&
-			e.key !== "Shift"
+			e.key !== "Shift" &&
+			e.key !== "Enter"
 		) {
 			searchInput.focus();
 		}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added condition to not focus on search bar when pressing enter.

#### Related Issues
https://github.com/eslint/eslint/issues/19501

#### Is there anything you'd like reviewers to focus on?
Similar to https://github.com/eslint/eslint/pull/19502

<!-- markdownlint-disable-file MD004 -->
