### PR TITLE
refactor: copy to clipboard code

### DIFF
--- a/src/_11ty/plugins/pre-wrapper.js
+++ b/src/_11ty/plugins/pre-wrapper.js
@@ -3,7 +3,7 @@ module.exports = md => {
 	md.renderer.rules.fence = (...args) => `
 <div class="code-wrapper">
     ${defaultFenceRenderer(...args)}
-    <button class="copy-btn" id="copyBtn" aria-labelledby="copy-button-label">
+    <button class="copy-btn" aria-labelledby="copy-button-label">
         <span hidden id="copy-button-label">Copy code to clipboard</span>
         <svg width="20" height="20" viewBox="0 0 20 20" role="img" aria-label="copy" fill="none" focusable="false">
             <path d="M4.16667 12.5H3.33333C2.89131 12.5 2.46738 12.3244 2.15482 12.0118C1.84226 11.6993 1.66667 11.2754 1.66667 10.8333V3.33332C1.66667 2.8913 1.84226 2.46737 2.15482 2.15481C2.46738 1.84225 2.89131 1.66666 3.33333 1.66666H10.8333C11.2754 1.66666 11.6993 1.84225 12.0118 2.15481C12.3244 2.46737 12.5 2.8913 12.5 3.33332V4.16666M9.16667 7.49999H16.6667C17.5871 7.49999 18.3333 8.24618 18.3333 9.16666V16.6667C18.3333 17.5871 17.5871 18.3333 16.6667 18.3333H9.16667C8.24619 18.3333 7.5 17.5871 7.5 16.6667V9.16666C7.5 8.24618 8.24619 7.49999 9.16667 7.49999Z" stroke="currentColor" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round" />

--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -65,23 +65,30 @@ document.addEventListener("DOMContentLoaded", () => {
 <div id="copy-announcement" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
 
 <script>
-    (function() {
-        const copyBtns = document.querySelectorAll("#copyBtn");
+    (function () {
+        const copyBtns = document.querySelectorAll(".copy-btn");
         const announcementRegion = document.getElementById("copy-announcement");
-        
+
         for (const copyBtn of copyBtns) {
-            const copyText = copyBtn.previousElementSibling.cloneNode(true).textContent;
+            const copyText = copyBtn.previousElementSibling.firstChild.textContent;
 
             copyBtn.onclick = () => {
-                navigator.clipboard.writeText(copyText);
-                announcementRegion.innerHTML = "Copied!";
-                copyBtn.setAttribute("data-copied", 'true');
+                navigator.clipboard
+                    .writeText(copyText)
+                    .then(() => {
+                        announcementRegion.innerHTML = "Copied!";
+                        copyBtn.setAttribute("data-copied", "true");
 
-                setTimeout(() => {
-                    copyBtn.removeAttribute("data-copied");
-                    announcementRegion.innerHTML = "";
-                }, 2000);
-            }
+                        setTimeout(() => {
+                            copyBtn.removeAttribute("data-copied");
+                            announcementRegion.innerHTML = "";
+                        }, 2000);
+                    })
+                    .catch((err) => {
+                        announcementRegion.innerHTML = "Failed to copy!";
+                        console.error("Clipboard write failed: ", err);
+                    });
+            };
         }
     })();
 </script>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).


#### What changes did you make? (Give an overview)
Refactored Copy to Clipboard functionality:
1. Cloning and then copying the `textContent` seems unnecessary; it's more efficient to access the `textContent` directly.
2. Assigning the same ID to all buttons is not recommended, as IDs should be unique. It's better to use a classname instead.
3. Use .then() with error handling when working with the navigator clipboard API because clipboard operations are asynchronous and can fail for several reasons like permission issues and Clipboard API Access Restrictions.
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
