### PR TITLE
fix: correct rule input menu styles

### DIFF
--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -54,6 +54,14 @@ const customStyles = {
 		color: "var(--body-text-color)",
 		caretShape: "underscore",
 	}),
+	indicatorsContainer: styles => ({
+		...styles,
+		cursor: "pointer",
+	}),
+	indicatorSeparator: styles => ({
+		...styles,
+		cursor: "auto",
+	}),
 	multiValue: styles => ({
 		...styles,
 		color: "var(--body-text-color)",

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -48,9 +48,6 @@ const customStyles = {
 			...styles[":active"],
 			backgroundColor: "var(--color-primary-700)",
 		},
-		":last-child": {
-			borderBottom: "1px solid var(--border-color)",
-		},
 	}),
 	input: styles => ({
 		...styles,
@@ -78,10 +75,12 @@ const customStyles = {
 		...styles,
 		backgroundColor: "var(--body-background-color)",
 		border: "1px solid var(--border-color)",
+		borderBottom: "none",
 	}),
 	menuList: styles => ({
 		...styles,
 		padding: 0,
+		borderBottom: "1px solid var(--border-color)",
 	}),
 };
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

### What changes did you make? (Give an overview)

#### Before

- Border bottom was missing in menu dropdown
-  Cursor was not pointer  for dropdownmenu icon

<img width="372" alt="Screenshot 2025-04-01 at 7 57 47 PM" src="https://github.com/user-attachments/assets/7091a487-ffeb-4b31-a35f-5214abf720da" />



#### After

<img width="366" alt="Screenshot 2025-04-01 at 7 58 58 PM" src="https://github.com/user-attachments/assets/75184034-3768-4a8a-b1c3-078d4d863bbf" />


#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
