### PR TITLE
feat: add report an issue button

### DIFF
--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -246,32 +246,6 @@
 	margin-top: 1rem;
 }
 
-.report-issue-btn {
-	display: inline-block;
-	background-color: var(--color-neutral-100);
-	border: 1px solid var(--border-color);
-	color: var(--body-text-color);
-	padding: 0.5rem 1rem;
-	border-radius: var(--border-radius);
-	font-size: 0.875rem;
-	cursor: pointer;
-	transition: all 0.2s ease;
-
-	&:hover {
-		background-color: var(--color-neutral-200);
-		color: var(--link-color);
-	}
-
-	[data-theme="dark"] & {
-		background-color: var(--color-neutral-700);
-		color: var(--color-neutral-100);
-
-		&:hover {
-			background-color: var(--color-neutral-600);
-		}
-	}
-}
-
 .playground__config-options__section--rules {
 	font-size: 0.875rem;
 }

--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -242,6 +242,36 @@
 	}
 }
 
+.report-issue-wrapper {
+	margin-top: 1rem;
+}
+
+.report-issue-btn {
+	display: inline-block;
+	background-color: var(--color-neutral-100);
+	border: 1px solid var(--border-color);
+	color: var(--body-text-color);
+	padding: 0.5rem 1rem;
+	border-radius: var(--border-radius);
+	font-size: 0.875rem;
+	cursor: pointer;
+	transition: all 0.2s ease;
+
+	&:hover {
+		background-color: var(--color-neutral-200);
+		color: var(--link-color);
+	}
+
+	[data-theme="dark"] & {
+		background-color: var(--color-neutral-700);
+		color: var(--color-neutral-100);
+
+		&:hover {
+			background-color: var(--color-neutral-600);
+		}
+	}
+}
+
 .playground__config-options__section--rules {
 	font-size: 0.875rem;
 }

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -362,6 +362,7 @@ const App = () => {
 						data-open={isConfigHidden ? true : showConfigMenu}
 					>
 						<Configuration
+							errors={messages}
 							initialOptions={fillOptionsDefaults(
 								getDefaultOptions(),
 							)}

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -112,6 +112,7 @@ export default function Configuration({
 	initialOptions,
 	rulesMeta,
 	eslintVersion,
+	errors,
 	onUpdate,
 	options,
 	ruleNames,
@@ -239,7 +240,11 @@ export default function Configuration({
 	return (
 		<div className="playground__config-options__sections">
 			<div className="playground__config-options__section">
-				<ShareURL url={window.location} />
+				<ShareURL
+					errors={errors}
+					url={window.location}
+					config={configFileContent}
+				/>
 			</div>
 			<div className="playground__config-options__section">
 				<button

--- a/src/playground/components/ShareURL.js
+++ b/src/playground/components/ShareURL.js
@@ -19,7 +19,9 @@ const buildGitHubIssueDescription = (code, config, errorOutput) => {
 	}
 
 	if (config) {
-		parts.push(`### ESLint Configuration\n${formatCodeBlock(config)}\n`);
+		parts.push(
+			`<details> \n <summary> ESLint Configuration </summary> \n\n${formatCodeBlock(config)}\n </details>\n`,
+		);
 	}
 
 	if (errorOutput) {

--- a/src/playground/components/ShareURL.js
+++ b/src/playground/components/ShareURL.js
@@ -3,6 +3,8 @@ import {
 	GITHUB_ISSUE_URL,
 	MAX_URL_LENGTH,
 	CLIPBOARD_FALLBACK_MESSAGE,
+	LINT_OUTPUT_FALLBACK_MESSAGE,
+	REPRO_URL_FALLBACK_MESSAGE,
 } from "../utils/constants";
 
 // Helper function for code template formatting
@@ -20,7 +22,7 @@ const buildGitHubIssueDescription = (code, config, errorOutput) => {
 
 	if (config) {
 		parts.push(
-			`<details> \n <summary> ESLint Configuration </summary> \n\n${formatCodeBlock(config)}\n </details>\n`,
+			`### ESLint Configuration \n<details> \n <summary> Tap to see full config </summary> \n\n${formatCodeBlock(config)}\n </details>\n`,
 		);
 	}
 
@@ -76,7 +78,7 @@ export default function ShareURL({ url, errors, config }) {
 		const errorOutput = formatErrors(errors);
 
 		// Build description with available data
-		const description = buildGitHubIssueDescription(
+		let description = buildGitHubIssueDescription(
 			code,
 			config,
 			errorOutput,
@@ -111,6 +113,8 @@ export default function ShareURL({ url, errors, config }) {
 
 		// Handle large content with clipboard fallback
 		if (reportUrl.search.length > MAX_URL_LENGTH) {
+			description += `### Link to Minimal Reproducible Example\n[Repro URL](${currentUrl})`;
+
 			reportUrl.searchParams.set(
 				"description",
 				CLIPBOARD_FALLBACK_MESSAGE,
@@ -119,6 +123,11 @@ export default function ShareURL({ url, errors, config }) {
 			if (description) {
 				navigator?.clipboard.writeText(description);
 			}
+			reportUrl.searchParams.set(
+				"lint-output",
+				LINT_OUTPUT_FALLBACK_MESSAGE,
+			);
+			reportUrl.searchParams.set("repro-url", REPRO_URL_FALLBACK_MESSAGE);
 		}
 
 		window.open(reportUrl, "_blank");

--- a/src/playground/components/ShareURL.js
+++ b/src/playground/components/ShareURL.js
@@ -1,16 +1,141 @@
 import React, { useState } from "react";
+import {
+	GITHUB_ISSUE_URL,
+	MAX_URL_LENGTH,
+	CLIPBOARD_FALLBACK_MESSAGE,
+} from "../utils/constants";
 
-export default function ShareURL({ url }) {
+// Helper function for code template formatting
+const formatCodeBlock = (code, lang = "js") => `\`\`\`${lang}
+${code}
+\`\`\``;
+
+// Helper to build GitHub issue description
+const buildGitHubIssueDescription = (code, config, errorOutput) => {
+	const parts = [];
+
+	if (code) {
+		parts.push(`### Playground Code\n${formatCodeBlock(code)}\n`);
+	}
+
+	if (config) {
+		parts.push(`### ESLint Configuration\n${formatCodeBlock(config)}\n`);
+	}
+
+	if (errorOutput) {
+		parts.push(`### ESLint Output\n\`\`\`\n${errorOutput}\n\`\`\`\n`);
+	}
+
+	return parts.join("\n");
+};
+
+export default function ShareURL({ url, errors, config }) {
 	const [isDataCopied, setIsDataCopied] = useState(false);
 	const [showShareURL, setShowShareURL] = useState(false);
+
+	// Extract code from editor or URL hash
+	const getEditorCode = () => {
+		try {
+			const editorContent = document.querySelector(
+				".playground__editor .cm-content",
+			);
+			if (editorContent) {
+				const lines = editorContent.querySelectorAll(".cm-line");
+				return Array.from(lines)
+					.map(line => line.textContent)
+					.join("\n");
+			}
+
+			if (window.location.hash) {
+				const decoded = JSON.parse(atob(window.location.hash.slice(1)));
+				return decoded?.text || "";
+			}
+		} catch {
+			// Silent catch
+		}
+		return "";
+	};
+
+	// Format errors for output
+	const formatErrors = errorList =>
+		errorList?.length
+			? errorList
+					.map(
+						({ line, column, message, ruleId }) =>
+							`${line}:${column} ${message} (${ruleId})`,
+					)
+					.join("\n")
+			: "";
+
+	const handleReportIssue = () => {
+		const reportUrl = new URL(GITHUB_ISSUE_URL);
+		const currentUrl = url || window.location.href;
+		const code = getEditorCode();
+		const errorOutput = formatErrors(errors);
+
+		// Build description with available data
+		const description = buildGitHubIssueDescription(
+			code,
+			config,
+			errorOutput,
+		);
+
+		// Set URL parameters
+		const params = {
+			labels: "bug,repro:yes",
+			template: "bug-report.yml",
+			"repro-url": currentUrl,
+			environment: "ESLint Playground",
+		};
+
+		if (errorOutput) {
+			params["lint-output"] = errorOutput;
+		}
+
+		if (code) {
+			params["what-did-you-do"] =
+				`I was using the ESLint Playground with this code:\n\n${formatCodeBlock(code)}`;
+		}
+
+		if (description) {
+			params.description = description;
+		}
+
+		// Add parameters to URL
+		Object.entries(params).forEach(([key, value]) => {
+			reportUrl.searchParams.append(key, value);
+		});
+
+		// Handle large content with clipboard fallback
+		if (reportUrl.search.length > MAX_URL_LENGTH) {
+			reportUrl.searchParams.set(
+				"description",
+				CLIPBOARD_FALLBACK_MESSAGE,
+			);
+
+			if (description) {
+				navigator?.clipboard.writeText(description);
+			}
+		}
+
+		window.open(reportUrl, "_blank");
+	};
+
+	const handleCopyUrl = () => {
+		const copyText = document.getElementById("code-snippet");
+		copyText.select();
+		navigator.clipboard.writeText(copyText.value);
+		setIsDataCopied(true);
+		setTimeout(() => setIsDataCopied(false), 4000);
+	};
 
 	return (
 		<div>
 			<button
 				className="playground-toggle c-btn c-btn--ghost"
-				onClick={() => setShowShareURL(currentValue => !currentValue)}
+				onClick={() => setShowShareURL(prev => !prev)}
 			>
-				<h2 data-config-section-title>Share URL</h2>
+				<h2 data-config-section-title>Share and Report</h2>
 				<svg
 					height="20"
 					width="20"
@@ -41,19 +166,7 @@ export default function ShareURL({ url }) {
 								className="share-url__btn"
 								id="copyBtn"
 								aria-labelledby="copy-button-label"
-								onClick={() => {
-									const copyText =
-										document.getElementById("code-snippet");
-
-									copyText.select();
-									navigator.clipboard.writeText(
-										copyText.value,
-									);
-									setIsDataCopied(true);
-									setTimeout(() => {
-										setIsDataCopied(false);
-									}, 4000);
-								}}
+								onClick={handleCopyUrl}
 							>
 								<span hidden id="copy-button-label">
 									Copy URL to clipboard
@@ -88,6 +201,14 @@ export default function ShareURL({ url }) {
 								Copied to clipboard.
 							</span>
 						)}
+					</div>
+					<div className="report-issue-wrapper">
+						<button
+							className="c-btn report-issue-btn"
+							onClick={handleReportIssue}
+						>
+							Report an issue
+						</button>
 					</div>
 				</div>
 			)}

--- a/src/playground/components/ShareURL.js
+++ b/src/playground/components/ShareURL.js
@@ -88,6 +88,7 @@ export default function ShareURL({ url, errors, config }) {
 			template: "bug-report.yml",
 			"repro-url": currentUrl,
 			environment: "ESLint Playground",
+			title: `Bug: [<rule name here>] <short description of the issue>`,
 		};
 
 		if (errorOutput) {

--- a/src/playground/components/ShareURL.js
+++ b/src/playground/components/ShareURL.js
@@ -204,7 +204,7 @@ export default function ShareURL({ url, errors, config }) {
 					</div>
 					<div className="report-issue-wrapper">
 						<button
-							className="c-btn report-issue-btn"
+							className="c-btn c-btn--secondary"
 							onClick={handleReportIssue}
 						>
 							Report an issue

--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -20,3 +20,11 @@ export const ECMA_VERSIONS = [
 export const SOURCE_TYPES = ["script", "module", "commonjs"];
 
 export const CONFIG_FORMATS = ["CommonJS", "ESM"];
+
+// GitHub Issue Reporting constants
+export const GITHUB_ISSUE_URL = "https://github.com/eslint/eslint/issues/new";
+
+export const MAX_URL_LENGTH = 8148;
+
+export const CLIPBOARD_FALLBACK_MESSAGE =
+	"<!-- The configuration and code have been saved to clipboard. Please paste them here 👇🏻 -->";

--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -28,3 +28,9 @@ export const MAX_URL_LENGTH = 8148;
 
 export const CLIPBOARD_FALLBACK_MESSAGE =
 	"<!-- The configuration and code have been saved to clipboard. Please paste them here 👇🏻 -->";
+
+export const REPRO_URL_FALLBACK_MESSAGE =
+	"<!-- The link to the minimal reproducible example has been copied in What did you do? field above. -->";
+
+export const LINT_OUTPUT_FALLBACK_MESSAGE =
+	"<!-- The lint output for what actually happened has been copied in What did you do? field above. -->";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->
- Add `Report an issue` button under Share section on playground

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Prefilled `Environment` with ESLint Playground text
- Prefilled `What did you do` with code, config and output
- Prefilled `What actually happened?` with output
- Prefilled `Link to Minimal Reproducible Example` with the shareable URL

#### Related Issues
Fix for https://github.com/eslint/eslint.org/issues/598

#### Is there anything you'd like reviewers to focus on?

Need opinion for the following edge case

- There is an edge case where if you enable add the rules, the config file becomes too big, and thus trying to create issue gives error of request URL too long. 

Following are the identified issues in case when all the rules were enabled

1. The shareable link which is generated (base64 config) is pretty big and we append it in the params, which when gets URL encoded becomes too big
2. We are adding template message only for the description field, but no such thing(length check) is being done for error output which in case of being too big causes error. 

Few probable solutions as per me could be

1. Shareable link will be always added irrespective of its length. but need to figure out if we can somehow shorten it
2. In case of too large error output, we can skip adding it by default to the error output field, since in description field as well, we add the error output.

<!-- markdownlint-disable-file MD004 -->

#### Screenshots


Prefilled `Environment` 
<img width="735" alt="Screenshot 2025-05-04 at 10 27 53 PM" src="https://github.com/user-attachments/assets/7674e820-d3d0-459b-846f-41ee91582bc6" />


Prefilled `What did you do` 
<img width="740" alt="Screenshot 2025-05-04 at 10 29 48 PM" src="https://github.com/user-attachments/assets/de02b16e-7382-4bce-99ad-bc75903bff37" />


Prefilled `What actually happened?` with error output and `Link to Minimal Reproducible Example` with the shareable URL 
<img width="743" alt="Screenshot 2025-05-04 at 10 30 12 PM" src="https://github.com/user-attachments/assets/7762c46d-0d55-4e98-86f5-441ff4624284" />


Prefilled `What did you do` with template message when config is too big 
<img width="765" alt="Screenshot 2025-05-05 at 8 42 22 AM" src="https://github.com/user-attachments/assets/2d05f357-ecb1-4d07-a1e8-b161524f39e0" />


Pasted config content in `What did you do` from clipboard when config is too big 
<img width="783" alt="Screenshot 2025-05-05 at 8 42 39 AM" src="https://github.com/user-attachments/assets/def7d3e4-59af-4ffc-8f65-238b151dfac6" />
