### PR TITLE
fix: reset btn styling

### DIFF
--- a/src/assets/scss/components/playground-configuration.scss
+++ b/src/assets/scss/components/playground-configuration.scss
@@ -324,9 +324,3 @@ ul.config__added-rules {
 		border-color: var(--color-rose-700);
 	}
 }
-
-.playground__config__revertConfig-btn {
-	background-color: var(--secondary-button-background-color);
-	color: var(--secondary-button-text-color);
-	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.1);
-}

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -625,7 +625,7 @@ export default function Configuration({
 
 					<button
 						onClick={revertToDefault}
-						className="c-btn playground__config__revertConfig-btn"
+						className="c-btn c-btn--secondary"
 					>
 						Reset
 					</button>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- Fixed styling of Reset Button with secondary-btn style used all over the project

#### Related Issues

#### Is there anything you'd like reviewers to focus on?
NA

<!-- markdownlint-disable-file MD004 -->

### Screenshots

`Before`

![2025-05-10 16 55 01](https://github.com/user-attachments/assets/32917905-0a7e-4586-a52a-d07d72aa102a)

`After`

![2025-05-10 16 54 29](https://github.com/user-attachments/assets/25d0992e-b0a4-4688-b3cb-60f84b8c8c76)

