### PR TITLE
feat: add condition to check TS parser

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -388,6 +388,7 @@ const App = () => {
 							setRulesWithInvalidConfigs={
 								setRulesWithInvalidConfigs
 							}
+							typeScriptESLintParser
 						/>
 						<Footer />
 					</div>

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -108,18 +108,6 @@ const defaultOption = {
 
 const isEmpty = obj => Object.keys(obj).length === 0;
 
-const parserValue = parser => {
-	if (
-		(typeof parser === "object" &&
-			parser.meta.name === "typescript-eslint/parser") ||
-		parser === "@typescript-eslint/parser"
-	) {
-		return "@typescript-eslint/parser";
-	}
-
-	return null;
-};
-
 export default function Configuration({
 	initialOptions,
 	rulesMeta,
@@ -131,6 +119,7 @@ export default function Configuration({
 	validationError,
 	rulesWithInvalidConfigs,
 	setRulesWithInvalidConfigs,
+	typeScriptESLintParser,
 }) {
 	const [showVersion, setShowVersions] = useState(false);
 	const [showRules, setShowRules] = useState(true);
@@ -270,6 +259,19 @@ export default function Configuration({
 		}
 
 		return config;
+	};
+
+	const parserValue = parser => {
+		if (
+			(typeof parser === "object" &&
+				parser.meta.name === "typescript-eslint/parser") ||
+			parser === "@typescript-eslint/parser" ||
+			parser === typeScriptESLintParser
+		) {
+			return "@typescript-eslint/parser";
+		}
+
+		return null;
 	};
 
 	// Remove empty objects from download configuration


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
https://github.com/eslint/eslint/blob/f46fc6c137c951bc73cf3bd9446053c1b11f769b/docs/.eleventy.js#L215-L217

To set the parser option to `@typescript-eslint/parser` in playground on `languageOptions.parser = typeScriptESLintParser` option, this will enable the TS parser when someone directly open the playground from `open in playground` button in docs.

#### What changes did you make? (Give an overview)
Added a condition to check if `parser === typeScriptESLintParser` then set the playground parser to `@typescript-eslint/parser`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Need to add this change before adding playground button for TypeScript code example https://github.com/eslint/eslint/pull/19671