### PR TITLE
fix: cursor jumps to start of line unexpectedly

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -7,6 +7,7 @@ import React, {
 	useCallback,
 	useRef,
 } from "react";
+import { flushSync } from "react-dom";
 import Alert from "./components/Alert";
 import CrashAlert from "./components/CrashAlert";
 import Footer from "./components/Footer";
@@ -303,15 +304,20 @@ const App = () => {
 		return () => mq.removeEventListener("change", ConfigToggler);
 	}, []);
 
+	// Please do not remove `flushSync`: https://github.com/eslint/eslint.org/pull/745
 	const debouncedOnUpdate = useMemo(
 		() =>
-			debounce(value => {
-				setFix(false);
-				setText(value);
-				storeState({ newText: value });
-			}, 400),
+			debounce(
+				value =>
+					flushSync(() => {
+						setFix(false);
+						setText(value);
+						storeState({ newText: value });
+					}),
+				400,
+			),
 		[storeState],
-	); // Maybe?
+	);
 
 	const [rulesWithInvalidConfigs, setRulesWithInvalidConfigs] = useState(
 		new Set([]),

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -311,7 +311,7 @@ const App = () => {
 				storeState({ newText: value });
 			}, 400),
 		[storeState],
-	);
+	); // Maybe?
 
 	const [rulesWithInvalidConfigs, setRulesWithInvalidConfigs] = useState(
 		new Set([]),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

In this PR, I’ve fixed the bug reported in #738.

After this fix, the cursor no longer jumps to the start of the line unexpectedly.

---

The source of the bug was the following code:

```js
setFix(false);
setText(value);
storeState({ newText: value });
```

In React, state updates using `setXXX` are asynchronous. This means that even though we expect `setText` to occur first and `storeState` to occur afterward, this order is not guaranteed.

This mismatch in behavior can cause the cursor to jump unexpectedly, since the order of state updates may become inconsistent in certain situations. When this happens, the cursor jumping bug occurs.

---

To fix this bug, I used the `flushSync` API from `react-dom`. This API ensures that state updates using `setXXX` are applied synchronously, so the order of state changes is guaranteed, and the bug no longer occurs.

---

I've tested this locally with both Chrome and Firefox, and it's working correctly on my end.

I'd appreciate it if @nzakas could verify this change on his end to see if it's working properly.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Fixes: #738

#### Is there anything you'd like reviewers to focus on?
