### PR TITLE
fix: playground crash due to ts parser

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -227,9 +227,18 @@ const App = () => {
 
 	const storeState = useCallback(
 		({ newText, newOptions }) => {
+			const opts = { ...options };
+
+			if (
+				opts.languageOptions &&
+				opts.languageOptions.parser === typeScriptESLintParser
+			) {
+				opts.languageOptions.parser = "@typescript-eslint/parser";
+			}
+
 			const serializedState = JSON.stringify({
 				text: newText,
-				options: newOptions || options,
+				options: newOptions || opts,
 			});
 
 			if (hasLocalStorage()) {

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -48,10 +48,6 @@ const fillOptionsDefaults = options => ({
 	...options,
 	languageOptions: {
 		...options.languageOptions,
-		...(options?.languageOptions?.parser ===
-			"@typescript-eslint/parser" && {
-			parser: typeScriptESLintParser,
-		}),
 		parserOptions: {
 			ecmaFeatures: {},
 			...options.languageOptions?.parserOptions,
@@ -227,18 +223,9 @@ const App = () => {
 
 	const storeState = useCallback(
 		({ newText, newOptions }) => {
-			const opts = { ...options };
-
-			if (
-				opts.languageOptions &&
-				opts.languageOptions.parser === typeScriptESLintParser
-			) {
-				opts.languageOptions.parser = "@typescript-eslint/parser";
-			}
-
 			const serializedState = JSON.stringify({
 				text: newText,
-				options: newOptions || opts,
+				options: newOptions || options,
 			});
 
 			if (hasLocalStorage()) {

--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -108,18 +108,6 @@ const defaultOption = {
 
 const isEmpty = obj => Object.keys(obj).length === 0;
 
-const parserValue = parser => {
-	if (
-		(typeof parser === "object" &&
-			parser.meta.name === "typescript-eslint/parser") ||
-		parser === "@typescript-eslint/parser"
-	) {
-		return "@typescript-eslint/parser";
-	}
-
-	return null;
-};
-
 export default function Configuration({
 	initialOptions,
 	rulesMeta,
@@ -260,11 +248,7 @@ export default function Configuration({
 		if (config.languageOptions && config.languageOptions.parser) {
 			const parser = config.languageOptions.parser;
 
-			if (
-				parser === "@typescript-eslint/parser" ||
-				(typeof parser === "object" &&
-					parser?.meta?.name === "typescript-eslint/parser")
-			) {
+			if (parser === "@typescript-eslint/parser") {
 				config.languageOptions.parser = "___TS_PARSER_PLACEHOLDER___";
 			}
 		}
@@ -493,9 +477,8 @@ export default function Configuration({
 								value={ESLintParserOptions.filter(
 									eslintParser =>
 										eslintParser.value ===
-										(parserValue(
-											options.languageOptions?.parser,
-										) || "default"),
+										(options.languageOptions?.parser ||
+											"default"),
 								)}
 								options={ESLintParserOptions}
 								onChange={selected => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Right now playground crashes because after a change in text or options the `parser` key in URL or LocalStorage sets to `typeScriptESLintParser` meta object rather than "@typescript-eslint/parser" string.

Steps to reproduce.

1 - Open Playground and set the parser to `@typescript-eslint/parser`.

2 - Change something in the text editor, like a space or anything.

3 - Then refresh the page.

https://eslint.org/play/#eyJ0ZXh0IjoiY29uc3QgZm9vID0gMTA7XG5cblxuIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6eyJqc3giOnRydWV9LCJzb3VyY2VUeXBlIjoibW9kdWxlIn0sInBhcnNlciI6eyJ2ZXJzaW9uIjoiOC4yOC4wIiwibWV0YSI6eyJuYW1lIjoidHlwZXNjcmlwdC1lc2xpbnQvcGFyc2VyIiwidmVyc2lvbiI6IjguMjguMCJ9fX19fQ==

<img width="1030" height="210" alt="Screenshot 2025-07-26 222237" src="https://github.com/user-attachments/assets/86e30366-b82c-4daa-a80d-abe0d1be696f" />


#### What changes did you make? (Give an overview)

Added a condition in `storeState` function, if `paser` is `typeScriptESLintParser` meta object then make is `parser = "@typescript-eslint/parser"`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
