### PR TITLE
fix: remove `ecmaFeatures.globalReturn` from playground

### DIFF
--- a/src/playground/utils/constants.js
+++ b/src/playground/utils/constants.js
@@ -1,4 +1,4 @@
-export const ECMA_FEATURES = ["jsx", "globalReturn", "impliedStrict"];
+export const ECMA_FEATURES = ["jsx", "impliedStrict"];
 
 export const ECMA_VERSIONS = [
 	"3",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Remove the `ecmaFeatures.globalReturn` option from the Playground to stay compatible with the next ESLint release, where this option will be removed.

#### What changes did you make? (Give an overview)

Removed `globalReturn` from the ECMA features allowlist

#### Related Issues

https://github.com/eslint/eslint/pull/20145

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
