### PR TITLE
feat: improve stats display with localization and accessibility

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -124,16 +124,23 @@ module.exports = eleventyConfig => {
 		DateTime.fromISO(isoDate).toFormat("d MMM"),
 	);
 
-	eleventyConfig.addFilter("shortNumber", number => {
-		if (number >= 1000000) {
-			return `${(number / 1000000).toFixed(1)}M`;
-		}
+	eleventyConfig.addFilter("formatStatsNumber", number => {
+		const formatOptions = {
+			notation: "compact",
+			maximumFractionDigits: 1,
+			minimumFractionDigits: 1,
+		};
 
-		if (number >= 1000) {
-			return `${(number / 1000).toFixed(1)}K`;
-		}
+		const formatter = new Intl.NumberFormat(siteName, formatOptions);
+		const formatterFull = new Intl.NumberFormat(siteName, {
+			...formatOptions,
+			compactDisplay: "long",
+		});
 
-		return number.toString();
+		return {
+			short: formatter.format(number),
+			full: formatterFull.format(number),
+		};
 	});
 
 	eleventyConfig.addFilter("readableDateFromISO", isoDate =>

--- a/src/_includes/components/stat.macro.html
+++ b/src/_includes/components/stat.macro.html
@@ -1,0 +1,6 @@
+{% macro statItem(statValue, statLabel) %}
+<div class="metrics__item" aria-label="{{ (statValue | formatStatsNumber).full}} {{ statLabel }}">
+    <span class="metrics__value" aria-hidden="true">{{ (statValue | formatStatsNumber).short }}</span>
+    <span aria-hidden="true">{{ statLabel }}</span>
+</div>
+{% endmacro %}

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -11,6 +11,8 @@ eleventyExcludeFromCollections: true
 
 {%- from 'components/donation.macro.html' import donationItem %}
 {%- from 'components/card.macro.html' import card %}
+{%- from 'components/stat.macro.html' import statItem %}
+
 
 <section class="section hero hero--homepage">
     <div class="content-container grid">
@@ -206,25 +208,16 @@ eleventyExcludeFromCollections: true
     <div class="content-container divider community-section">
         <header class="section-head center-text">
             <h2 class="section-title h3">{{ site.homepage.stats.title }}</h2>
-            {% set download_count = stats.weeklyDownloads | shortNumber %}
+            {% set download_count = (stats.weeklyDownloads | formatStatsNumber).full %}
             {% set stats_desc = site.homepage.stats.description | replace("DOWNLOAD_COUNT", download_count) %}
             <p class="section-supporting-text fs-step-0">
                 {{ stats_desc }}
             </p>
         </header>
         <div class="metrics center-text">
-            <div class="metrics__item">
-                <span class="metrics__value">{{ stats.projectDependents | shortNumber }}</span>
-                <span>{{ site.homepage.stats.dependents }}</span>
-            </div>
-            <div class="metrics__item">
-                <span class="metrics__value">{{ stats.weeklyDownloads | shortNumber }}</span>
-                <span>{{ site.homepage.stats.weekly_downloads }}</span>
-            </div>
-            <div class="metrics__item">
-                <span class="metrics__value">{{ stats.stars | shortNumber }}</span>
-                <span>{{ site.homepage.stats.stars }}</span>
-            </div>
+            {{ statItem(stats.projectDependents, site.homepage.stats.dependents) }}
+            {{ statItem(stats.weeklyDownloads, site.homepage.stats.weekly_downloads) }}
+            {{ statItem(stats.stars, site.homepage.stats.stars) }}
         </div>
     </div>
 </section>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Improve localization and accessibility in the stats section

#### What changes did you make? (Give an overview)

- Display stats in the site's language rather than English. (e.g., in `zh-hans`, `27.3M` -> `2728.7万`)

<img width="1258" height="307" alt="image" src="https://github.com/user-attachments/assets/21e554cc-04c8-4a89-be24-410e977a18a0" />
<img width="1273" height="325" alt="image" src="https://github.com/user-attachments/assets/f962c502-cec3-442c-9fdd-013a699341ee" />

- Use the full unit name (e.g., `M` - > `millions`) in aria-labels for improved clarity. More user-friendly for screen reader users

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
