### PR TITLE
fix: correct 404 page image path

### DIFF
--- a/src/content/pages/404.html
+++ b/src/content/pages/404.html
@@ -22,7 +22,7 @@ hook: "404_page"
         </div>
 
         <div class="content-container span-7-12">
-            <img width="480" height="366" src="../../assets/images/404.png" alt="" loading="lazy">
+            <img width="480" height="366" src="/assets/images/404.png" alt="" loading="lazy">
         </div>
     </div>
 </section>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes the broken illustration on the 404 page. The image was not loading when visiting nested URLs (for example:
https://eslint.org/blog/2015/06/eslint-0.24.0-released/preparing-for-1.0.0)

#### What changes did you make? (Give an overview)

Updated the `src` attribute for the 404 image from a relative path `(../../assets/images/404.png)` to a root-relative path `(/assets/images/404.png)`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
