### PR TITLE
fix: use team member's username when name is not available

### DIFF
--- a/src/_11ty/plugins/md-syntax-highlighter.js
+++ b/src/_11ty/plugins/md-syntax-highlighter.js
@@ -69,7 +69,6 @@ const lineNumberPlugin = md => {
 			rawCode.indexOf("</code>"),
 		);
 		const lines = code.split("\n");
-		console.log(lines.length);
 		const lineNumbersCode = [...Array(lines.length - 1)]
 			.map(
 				(line, index) =>

--- a/src/content/pages/team.html
+++ b/src/content/pages/team.html
@@ -26,7 +26,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.tsc %}
                     {% set itemPhoto = item.avatar_url %}
-                    {% set itemName = item.name %}
+                    {% set itemName = item.name or item.username %}
                     {% set itemHandle = item.username %}
 
                     {% set itemBio = item.bio | safe %}
@@ -68,7 +68,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.reviewers %}
                     {% set itemPhoto = item.avatar_url %}
-                    {% set itemName = item.name %}
+                    {% set itemName = item.name or item.username %}
                     {% set itemHandle = item.username %}
 
                     {% set itemBio = item.bio | safe %}
@@ -110,7 +110,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.committers %}
                     {% set itemPhoto = item.avatar_url %}
-                    {% set itemName = item.name %}
+                    {% set itemName = item.name or item.username %}
                     {% set itemHandle = item.username %}
 
                     {% set itemBio = item.bio | safe %}
@@ -152,7 +152,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.website %}
                 {% set itemPhoto = item.avatar_url %}
-                {% set itemName = item.name %}
+                {% set itemName = item.name or item.username %}
                 {% set itemHandle = item.username %}
 
                 {% set itemBio = item.bio | safe %}
@@ -194,7 +194,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.support %}
                 {% set itemPhoto = item.avatar_url %}
-                {% set itemName = item.name %}
+                {% set itemName = item.name or item.username %}
                 {% set itemHandle = item.username %}
 
                 {% set itemBio = item.bio | safe %}
@@ -236,7 +236,7 @@ hook: "team_page"
             <ul role="list" class="span-6-12 people-list">
                 {% for item in team.alumni %}
                     {% set itemPhoto = item.avatar_url %}
-                    {% set itemName = item.name %}
+                    {% set itemName = item.name or item.username %}
                     {% set itemHandle = item.username %}
 
                     <li>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR ensures the team page handles missing names gracefully by falling back to usernames when names are not available.

#### What changes did you make? (Give an overview)

Updated all team sections in the template to use a fallback for `itemName`:

```md
{% set itemName = item.name or item.username %}
```

I also removed a leftover `console.log(lines.length);` from #802 that was printing unnecessary numbers during the build.

#### Related Issues

Fixes #806

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
