### PR TITLE
fix: improve web accessibility by hiding non-semantic character

### DIFF
--- a/src/assets/scss/footer.scss
+++ b/src/assets/scss/footer.scss
@@ -29,7 +29,7 @@
 			margin-inline-end: 0.5rem;
 
 			&:not(:last-of-type)::after {
-				content: "|";
+				content: "|" / "";
 				margin-left: 0.5rem;
 				margin-inline-start: 0.5rem;
 			}

--- a/src/assets/scss/languages.scss
+++ b/src/assets/scss/languages.scss
@@ -27,7 +27,7 @@
 			color: var(--link-color);
 
 			&::after {
-				content: "✔️";
+				content: "✔️" / "check mark";
 			}
 		}
 

--- a/src/assets/scss/versions.scss
+++ b/src/assets/scss/versions.scss
@@ -28,7 +28,7 @@
 			color: var(--link-color);
 
 			&::after {
-				content: "✔️";
+				content: "✔️" / "check mark";
 			}
 		}
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR is a follow-up to https://github.com/eslint/eslint/pull/20181.

In this PR, I've added alternative text for the indicator `|` and emojis.

<img width="1156" height="58" alt="image" src="https://github.com/user-attachments/assets/8bd58eaa-ee0d-49d7-8d99-14e0b0e688dd" />

Previously, screen readers would read out the indicator `|`, which could be distracting.

#### What changes did you make? (Give an overview)

I've improved web accessibility by hiding non-semantic character.

#### Related Issues

Ref: https://github.com/eslint/eslint/pull/20181

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

The MDN reference is here: https://developer.mozilla.org/en-US/docs/Web/CSS/content#try_it
