### PR TITLE
fix: unexpected `undefined` inserted when downloading config

### DIFF
--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -278,7 +278,7 @@ export default function Configuration({
 		normalizeParser(optionsForConfigFile);
 
 	const configFileContent =
-		`${options.languageOptions.parser && 'import tsParser from "@typescript-eslint/parser";'}\n${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([configOptionsWithNormalizedParser], null, 4)};`.replace(
+		`${options.languageOptions.parser ? 'import tsParser from "@typescript-eslint/parser";\n' : ""}${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([configOptionsWithNormalizedParser], null, 4)};`.replace(
 			/"___TS_PARSER_PLACEHOLDER___"/gu,
 			"tsParser",
 		);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### What did you do?

When I click the 'Download this config file' button below, an unexpected `undefined` is inserted.

This behavior can be reproduced when the ESLint Playground is using the default setup.

<img width="449" height="177" alt="image" src="https://github.com/user-attachments/assets/3159c0a6-8f54-4ba0-951e-2a7350fa70e7" />

Result: 

```js
undefined // <- Bug
export default [
    {
        "rules": {
            "constructor-super": [
                "error"
            ],
            "for-direction": [
                "error"
            ],
            "getter-return": [
                "error"
            ],
            "no-async-promise-executor": [
                "error"
            ],
            "no-case-declarations": [
                "error"
            ],
            "no-class-assign": [
                "error"
            ],
            "no-compare-neg-zero": [
                "error"
            ],
            "no-cond-assign": [
                "error"
            ],
            "no-const-assign": [
                "error"
            ],
            "no-constant-binary-expression": [
                "error"
            ],
            "no-constant-condition": [
                "error"
            ],
            "no-control-regex": [
                "error"
            ],
            "no-debugger": [
                "error"
            ],
            "no-delete-var": [
                "error"
            ],
            "no-dupe-args": [
                "error"
            ],
            "no-dupe-class-members": [
                "error"
            ],
            "no-dupe-else-if": [
                "error"
            ],
            "no-dupe-keys": [
                "error"
            ],
            "no-duplicate-case": [
                "error"
            ],
            "no-empty": [
                "error"
            ],
            "no-empty-character-class": [
                "error"
            ],
            "no-empty-pattern": [
                "error"
            ],
            "no-empty-static-block": [
                "error"
            ],
            "no-ex-assign": [
                "error"
            ],
            "no-extra-boolean-cast": [
                "error"
            ],
            "no-fallthrough": [
                "error"
            ],
            "no-func-assign": [
                "error"
            ],
            "no-global-assign": [
                "error"
            ],
            "no-import-assign": [
                "error"
            ],
            "no-invalid-regexp": [
                "error"
            ],
            "no-irregular-whitespace": [
                "error"
            ],
            "no-loss-of-precision": [
                "error"
            ],
            "no-misleading-character-class": [
                "error"
            ],
            "no-new-native-nonconstructor": [
                "error"
            ],
            "no-nonoctal-decimal-escape": [
                "error"
            ],
            "no-obj-calls": [
                "error"
            ],
            "no-octal": [
                "error"
            ],
            "no-prototype-builtins": [
                "error"
            ],
            "no-redeclare": [
                "error"
            ],
            "no-regex-spaces": [
                "error"
            ],
            "no-self-assign": [
                "error"
            ],
            "no-setter-return": [
                "error"
            ],
            "no-shadow-restricted-names": [
                "error"
            ],
            "no-sparse-arrays": [
                "error"
            ],
            "no-this-before-super": [
                "error"
            ],
            "no-undef": [
                "error"
            ],
            "no-unexpected-multiline": [
                "error"
            ],
            "no-unreachable": [
                "error"
            ],
            "no-unsafe-finally": [
                "error"
            ],
            "no-unsafe-negation": [
                "error"
            ],
            "no-unsafe-optional-chaining": [
                "error"
            ],
            "no-unused-labels": [
                "error"
            ],
            "no-unused-private-class-members": [
                "error"
            ],
            "no-unused-vars": [
                "error"
            ],
            "no-useless-backreference": [
                "error"
            ],
            "no-useless-catch": [
                "error"
            ],
            "no-useless-escape": [
                "error"
            ],
            "no-with": [
                "error"
            ],
            "require-yield": [
                "error"
            ],
            "use-isnan": [
                "error"
            ],
            "valid-typeof": [
                "error"
            ]
        }
    }
];
```

### What did you expect to happen?

No `undefined` is inserted at the top of the file.

### What actually happened?

`undefined` is inserted at the top of the file.

## What changes did you make? (Give an overview)

The `&&` operator was causing a problem here. When `options.languageOptions.parser` evaluated to `undefined`, short-circuiting made the first line return `undefined`. 

I fixed this by using the ternary operator to prevent that behavior.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
