### PR TITLE
feat: enable `docs/next`

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -112,8 +112,11 @@ eleventyExcludeFromCollections: true
 /docs/v9.x/*                        https://eslint.org/docs/latest/:splat 302!
 
 # Docs for the current prerelease
-# As there is currently no active prerelease, redirect to latest docs
-/docs/next/*                        https://eslint.org/docs/latest/:splat 302!
+{% if site.locals.docs_next %}
+/docs/next/*                        https://{{ site.locals.docs_next }}/:splat 200!
+{% else %}
+/docs/next/*                        https://eslint.org/docs/next/:splat 302!
+{% endif %}
 
 {% if site.locals.blog == false %}
 # Redirect blog back to English site


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Updates the redirects file to enable `/docs/next/`, where we'll have the ESLint v10 prerelease docs.

#### What changes did you make? (Give an overview)

Updated `src/static/redirects.njk` the same as it was done for v9 prereleases (https://github.com/eslint/eslint.org/commit/f10378f4bd37dbaef91c56adf693941e4b98611c).

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

This is ready for review, but marked as draft as it should be merged right after we release ESLint v10.0.0-alpha.0.
