### PR TITLE
chore: update default example to use `prefer-const` rule

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -23,8 +23,7 @@ import * as typeScriptESLintParser from "@typescript-eslint/parser";
 
 const BOM = "\uFEFF";
 
-const DEFAULT_TEXT =
-	'/* eslint quotes: ["error", "double"] */\nconst a = \'b\';';
+const DEFAULT_TEXT = '/* eslint prefer-const: "error" */\nlet a = "b";';
 
 const linter = new Linter({ configType: "flat" });
 const legacyLinter = new Linter({ configType: "eslintrc" });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update the playground's default example to use the `prefer-const` rule instead of the deprecated `quotes` rule, which will be removed in v11.

#### What changes did you make? (Give an overview)

Replaced the default code example from using the deprecated `quotes` rule to the `prefer-const` rule

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
