### PR TITLE
chore: update `js-yaml` to `v3.14.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "hyperlink": "^5.0.4",
         "imagemin": "^8.0.1",
         "imagemin-cli": "^7.0.0",
-        "js-yaml": "^3.14.1",
+        "js-yaml": "^3.14.2",
         "lint-staged": "^13.3.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.6.7",
@@ -12264,10 +12264,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "hyperlink": "^5.0.4",
     "imagemin": "^8.0.1",
     "imagemin-cli": "^7.0.0",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^3.14.2",
     "lint-staged": "^13.3.0",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.6.7",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR was motivated by https://github.com/eslint/eslint.org/pull/843.

In this PR, I've updated `js-yaml` to `v3.14.2` to address security vulnerabilities in `js-yaml@3.14.1`.

v3.14.2 includes a backported bug fix that resolves the security issue without requiring an upgrade to v4.

Ref: https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#3142---2025-11-15

#### What changes did you make? (Give an overview)

In this PR, I've updated `js-yaml` to `v3.14.2` to address security vulnerabilities in `js-yaml@3.14.1`.

#### Related Issues

Ref: #843

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A