### PR TITLE
chore: declare playground module type

### DIFF
--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "The codebase for the ESLint PLayground (play.eslint.org)",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "eslint": "latest"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,9 @@ module.exports = (env, { mode }) => ({
 						],
 					],
 				},
+				resolve: {
+					fullySpecified: false,
+				},
 			},
 			{
 				test: /\.scss$/u,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

While working on adding a postinstall script in #853, Node.js showed this warning:

```
(node:11740) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of postinstall.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to package.json.
```

This PR makes the module format explicit by declaring ES modules, which the playground already uses.

#### What changes did you make? (Give an overview)

- Added `"type": "module"` to playground `package.json` to declare ES module format
- Added `resolve: { fullySpecified: false }` to webpack config. ES modules require extensions on imports, but this setting maintains compatibility with our existing extensionless imports.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
