### PR TITLE
ci: align node version with `.nvmrc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: "npm"
       - name: Install website dependencies
         run: npm ci


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR aligns the Node.js version used in our GitHub Actions CI workflow with the version specified in the `.nvmrc` file. This resolves a version mismatch where CI was using the latest LTS (Node 24) while Netlify uses Node 20, preventing inconsistent build failures.

#### What changes did you make? (Give an overview)

Updated `ci.yml` to use the `node-version-file` parameter instead of a fixed `lts/*` version.

#### Related Issues

https://github.com/eslint/eslint.org/pull/853

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
