### PR TITLE
fix: use `require()` for TypeScript parser in CommonJS configs

### DIFF
--- a/src/playground/components/configuration.jsx
+++ b/src/playground/components/configuration.jsx
@@ -277,8 +277,18 @@ export default function Configuration({
 	const configOptionsWithNormalizedParser =
 		normalizeParser(optionsForConfigFile);
 
+	const isESM = configFileFormat === "ESM";
+	const exportStatement = isESM ? "export default" : "module.exports =";
+
+	let parserImport = "";
+	if (options.languageOptions.parser) {
+		parserImport = isESM
+			? 'import tsParser from "@typescript-eslint/parser";\n'
+			: 'const tsParser = require("@typescript-eslint/parser");\n';
+	}
+
 	const configFileContent =
-		`${options.languageOptions.parser ? 'import tsParser from "@typescript-eslint/parser";\n' : ""}${configFileFormat === "ESM" ? "export default" : "module.exports ="} ${JSON.stringify([configOptionsWithNormalizedParser], null, 4)};`.replace(
+		`${parserImport}${exportStatement} ${JSON.stringify([configOptionsWithNormalizedParser], null, 4)};`.replace(
 			/"___TS_PARSER_PLACEHOLDER___"/gu,
 			"tsParser",
 		);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes a bug where the ESLint playground generates syntactically invalid configuration files when users select CommonJS format while using the TypeScript parser.

#### What changes did you make? (Give an overview)

Updated the configuration file generation logic to use the appropriate import/require syntax based on the selected module format.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
