### PR TITLE
chore: fix playground license

### DIFF
--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "The codebase for the ESLint Playground (eslint.org/play)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
     "eslint": "latest"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

When working on the playground, I noticed that its `package.json` specifies an `MIT` license while the project's LICENSE file uses `Apache-2.0`. The root `package.json` was updated in #379 to fix this same issue, but it looks like we simply forgot to update the playground.

#### What changes did you make? (Give an overview)

Updated `src/playground/package.json` license field from `MIT` to `Apache-2.0`

I'd like @eslint/eslint-tsc to verify this change.
