### PR TITLE
feat: generate configs with `defineConfig` helper

### DIFF
--- a/src/playground/components/configuration.jsx
+++ b/src/playground/components/configuration.jsx
@@ -277,41 +277,37 @@ export default function Configuration({
 	const configOptionsWithNormalizedParser =
 		normalizeParser(optionsForConfigFile);
 
-	const generateConfigFileContent = () => {
-		const configString = JSON.stringify(
-			[configOptionsWithNormalizedParser],
-			null,
-			4,
-		);
-		const isESM = configFileFormat === "ESM";
+	const configString = JSON.stringify(
+		[configOptionsWithNormalizedParser],
+		null,
+		4,
+	);
+	const isESM = configFileFormat === "ESM";
 
-		let imports = "";
+	let imports = "";
 
+	if (isESM) {
+		imports += 'import { defineConfig } from "eslint/config";\n';
+	} else {
+		imports += 'const { defineConfig } = require("eslint/config");\n';
+	}
+
+	if (options.languageOptions.parser) {
 		if (isESM) {
-			imports += 'import { defineConfig } from "eslint/config";\n';
+			imports += 'import tsParser from "@typescript-eslint/parser";\n';
 		} else {
-			imports += 'const { defineConfig } = require("eslint/config");\n';
+			imports +=
+				'const tsParser = require("@typescript-eslint/parser");\n';
 		}
+	}
 
-		if (options.languageOptions.parser) {
-			if (isESM) {
-				imports +=
-					'import tsParser from "@typescript-eslint/parser";\n';
-			} else {
-				imports +=
-					'const tsParser = require("@typescript-eslint/parser");\n';
-			}
-		}
+	const exportStatement = isESM ? "export default" : "module.exports =";
 
-		const exportStatement = isESM ? "export default" : "module.exports =";
-
-		return `${imports}\n${exportStatement} defineConfig(${configString});`.replace(
+	const configFileContent =
+		`${imports}\n${exportStatement} defineConfig(${configString});`.replace(
 			/"___TS_PARSER_PLACEHOLDER___"/gu,
 			"tsParser",
 		);
-	};
-
-	const configFileContent = generateConfigFileContent();
 
 	return (
 		<div className="playground__config-options__sections">


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates the Playground to generate configuration files using the `defineConfig()` helper

#### What changes did you make? (Give an overview)

Updated the configuration download feature to wrap generated configs with `defineConfig()`

#### Related Issues

Closes #885

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
