### PR TITLE
feat: enable `docs/v9.x`

### DIFF
--- a/src/_data/sites/de.yml
+++ b/src/_data/sites/de.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: docs-eslint.netlify.app
   docs_next: next--docs-eslint.netlify.app
   docs_v8: v8-x--docs-eslint.netlify.app
+  docs_v9: v9-x--docs-eslint.netlify.app
   blog: true
   version_support: true
 redirects:

--- a/src/_data/sites/es.yml
+++ b/src/_data/sites/es.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/fr.yml
+++ b/src/_data/sites/fr.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/hi.yml
+++ b/src/_data/sites/hi.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/ja.yml
+++ b/src/_data/sites/ja.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/pt-br.yml
+++ b/src/_data/sites/pt-br.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/_data/sites/zh-hans.yml
+++ b/src/_data/sites/zh-hans.yml
@@ -21,6 +21,7 @@ locals:
   docs_head: false
   docs_next: false
   docs_v8: false
+  docs_v9: false
   blog: false
   version_support: false
 

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -108,8 +108,11 @@ eleventyExcludeFromCollections: true
 {% endif %}
 
 # Docs for the latest v9.x
-# Redirect to latest docs while v9.x is the latest release
-/docs/v9.x/*                        https://eslint.org/docs/latest/:splat 302!
+{% if site.locals.docs_v9 %}
+/docs/v9.x/*                        https://{{ site.locals.docs_v9 }}/:splat 200!
+{% else %}
+/docs/v9.x/*                        https://eslint.org/docs/v9.x/:splat 302!
+{% endif %}
 
 # Docs for the current prerelease
 {% if site.locals.docs_next %}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enables `https://eslint.org/docs/v9.x/*` docs.

#### What changes did you make? (Give an overview)

Replaced redirecting to `latest` with proxying to the docs site that is built from eslint/eslint repo's `v9.x` branch.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

This should be merged right before the final v10.0.0 release.

There will be a separate PR to redirect `next` and `v10.x` to `latest`, because that one should be merged after the release.
