### PR TITLE
feat: redirect `docs/next` and `docs/v10.x` to `docs/latest`

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -111,12 +111,13 @@ eleventyExcludeFromCollections: true
 # Redirect to latest docs while v9.x is the latest release
 /docs/v9.x/*                        https://eslint.org/docs/latest/:splat 302!
 
+# Docs for the latest v10.x
+# Redirect to latest docs while v10.x is the latest release
+/docs/v10.x/*                        https://eslint.org/docs/latest/:splat 302!
+
 # Docs for the current prerelease
-{% if site.locals.docs_next %}
-/docs/next/*                        https://{{ site.locals.docs_next }}/:splat 200!
-{% else %}
-/docs/next/*                        https://eslint.org/docs/next/:splat 302!
-{% endif %}
+# As there is currently no active prerelease, redirect to latest docs
+/docs/next/*                        https://eslint.org/docs/latest/:splat 302!
 
 {% if site.locals.blog == false %}
 # Redirect blog back to English site


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Redirects `docs/next/*` and `docs/v10.x/*` to `docs/latest/*`. 

#### What changes did you make? (Give an overview)

Updated `src/static/redirects.njk` accordingly.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

This should be merged after the final v10.0.0 release.

I think this will not run into merge conflicts with https://github.com/eslint/eslint.org/pull/922.
