### PR TITLE
chore: refactor playground eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,15 +45,16 @@ module.exports = defineConfig([
 	{
 		files: [playgroundFiles],
 		ignores: ["src/playground/scripts/**/*.js"],
-		extends: [eslintConfigESLintBase],
-		plugins: {
-			react: reactPlugin,
-			"jsx-a11y": jsxA11yPlugin,
-			"react-hooks": reactHooksPlugin,
-		},
+		extends: [
+			eslintConfigESLintBase,
+			reactPlugin.configs.flat.recommended,
+			reactPlugin.configs.flat["jsx-runtime"],
+			jsxA11yPlugin.flatConfigs.recommended,
+			reactHooksPlugin.configs.flat.recommended,
+		],
 		settings: {
 			react: {
-				version: "19.1.0",
+				version: "detect",
 			},
 		},
 		languageOptions: {
@@ -69,19 +70,11 @@ module.exports = defineConfig([
 			},
 		},
 		rules: {
-			...reactPlugin.configs.flat.recommended.rules,
-			...jsxA11yPlugin.configs.recommended.rules,
-			...reactHooksPlugin.configs.flat.recommended.rules,
-			"react/react-in-jsx-scope": "off",
-			"react/jsx-uses-react": "off",
 			"react/jsx-no-useless-fragment": "error",
-			"react/jsx-no-target-blank": "error",
 
 			// Disable rules that the codebase doesn't currently follow.
 			// It might be a good idea to enable these in the future.
-			"jsx-a11y/no-onchange": "off",
 			"react/prop-types": "off",
-			"jsdoc/require-jsdoc": "off",
 			"func-style": "off",
 		},
 	},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR simplifies and modernizes the ESLint configuration for playground files by using flat configs instead of manually defining rules and plugins.

#### What changes did you make? (Give an overview)

- Replaced manual plugin and rule definitions with their provided flat configurations in the `extends` array.
- Added `reactPlugin.configs.flat['jsx-runtime']` to automatically handle modern React requirements, eliminating the need for manual overrides like `react-in-jsx-scope`.
- Switched the React version setting to `detect`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
