### PR TITLE
fix: sync configuration file format dropdown with state in playground

### DIFF
--- a/src/playground/components/configuration.jsx
+++ b/src/playground/components/configuration.jsx
@@ -793,8 +793,9 @@ export default function Configuration({
 							isSearchable={false}
 							styles={customStyles}
 							theme={theme => customTheme(theme)}
-							defaultValue={configFileFormatOptions.filter(
-								formatOption => formatOption.value === "ESM",
+							value={configFileFormatOptions.find(
+								formatOption =>
+									formatOption.value === configFileFormat,
 							)}
 							options={configFileFormatOptions}
 							onChange={selected => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes a bug in the Playground where the "Configuration File Format" dropdown would incorrectly highlight "CommonJS" when reopened, even if "ESM" was the currently selected format.

#### What changes did you make? (Give an overview)

Replaced `defaultValue` with `value` on the `Select` component for Configuration File Format. This ensures the dropdown always reflects the actual React state.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
