### PR TITLE
fix: continue sponsor data fetch when one source fails

### DIFF
--- a/.github/workflows/data-fetch.yml
+++ b/.github/workflows/data-fetch.yml
@@ -36,6 +36,8 @@ jobs:
         ESLINT_GITHUB_TOKEN: ${{ secrets.DATA_FETCH_TOKEN }}
 
     - name: Fetch sponsor data
+      id: fetch_sponsor_data
+      continue-on-error: true
       run: npm run fetch:sponsors
       env:
         ESLINT_GITHUB_TOKEN: ${{ secrets.DATA_FETCH_TOKEN }}
@@ -52,3 +54,9 @@ jobs:
       run: |
         chmod +x ./tools/commit-data.sh
         ./tools/commit-data.sh
+
+    - name: Fail if sponsor data fetch had source failures
+      if: ${{ steps.fetch_sponsor_data.outcome == 'failure' }}
+      run: |
+        echo "Sponsor data fetch completed with one or more source failures."
+        exit 1

--- a/.github/workflows/data-fetch.yml
+++ b/.github/workflows/data-fetch.yml
@@ -58,5 +58,5 @@ jobs:
     - name: Fail if sponsor data fetch had source failures
       if: ${{ steps.fetch_sponsor_data.outcome == 'failure' }}
       run: |
-        echo "Sponsor data fetch completed with one or more source failures."
+        echo "Sponsor data fetch completed with source failures: ${{ steps.fetch_sponsor_data.outputs.failed_sources }}"
         exit 1

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -130,6 +130,24 @@ function getExistingDonationsBySource(existingDonationsData, source) {
 }
 
 /**
+ * Appends a GitHub Actions step output if `GITHUB_OUTPUT` is available.
+ * @param {string} name The output name.
+ * @param {string} value The output value.
+ * @returns {Promise<void>} A promise that resolves when the output has been handled.
+ */
+async function setGitHubActionOutput(name, value) {
+	const { GITHUB_OUTPUT } = process.env;
+
+	if (!GITHUB_OUTPUT) {
+		return;
+	}
+
+	await fs.appendFile(GITHUB_OUTPUT, `${name}=${value}\n`, {
+		encoding: "utf8",
+	});
+}
+
+/**
  * Fetch order data from Open Collective using the GraphQL API.
  * @returns {Promise<{sponsors: Array, donations: Array}>} An promise that resolves to an object with two properties:
  *  - `sponsors` (Array): List of sponsors
@@ -500,7 +518,7 @@ async function fetchThanksDevData() {
 				.readFile(blockedSponsorsFilename, { encoding: "utf8" })
 				.then(data => JSON.parse(data)),
 		]);
-	let hadSourceFetchFailure = false;
+	const failedSources = [];
 
 	const [
 		{
@@ -511,7 +529,7 @@ async function fetchThanksDevData() {
 		{ sponsors: thanksDevSponsors },
 	] = await Promise.all([
 		fetchOpenCollectiveData().catch(error => {
-			hadSourceFetchFailure = true;
+			failedSources.push("Open Collective");
 			console.error("Failed to fetch Open Collective data.", error);
 			return {
 				sponsors: getExistingSponsorsBySource(
@@ -525,7 +543,7 @@ async function fetchThanksDevData() {
 			};
 		}),
 		fetchGitHubSponsors().catch(error => {
-			hadSourceFetchFailure = true;
+			failedSources.push("GitHub Sponsors");
 			console.error("Failed to fetch GitHub Sponsors data.", error);
 			return {
 				sponsors: getExistingSponsorsBySource(
@@ -539,7 +557,7 @@ async function fetchThanksDevData() {
 			};
 		}),
 		fetchThanksDevData().catch(error => {
-			hadSourceFetchFailure = true;
+			failedSources.push("thanks.dev");
 			console.error("Failed to fetch thanks.dev data.", error);
 			return {
 				sponsors: getExistingSponsorsBySource(
@@ -549,6 +567,10 @@ async function fetchThanksDevData() {
 			};
 		}),
 	]);
+
+	const failedSourcesText = failedSources.join(", ");
+
+	await setGitHubActionOutput("failed_sources", failedSourcesText);
 
 	const sponsors = openCollectiveSponsors
 		.concat(githubSponsors)
@@ -640,9 +662,9 @@ async function fetchThanksDevData() {
 		encoding: "utf8",
 	});
 
-	if (hadSourceFetchFailure) {
+	if (failedSources.length > 0) {
 		throw new Error(
-			"Sponsor data fetch completed with one or more source failures.",
+			`Sponsor data fetch completed with source failures: ${failedSourcesText}.`,
 		);
 	}
 })();

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -475,9 +475,26 @@ async function fetchThanksDevData() {
 		{ sponsors: thanksDevSponsors },
 		blockedSponsors,
 	] = await Promise.all([
-		fetchOpenCollectiveData(),
-		fetchGitHubSponsors(),
-		fetchThanksDevData(),
+		fetchOpenCollectiveData().catch(error => {
+			console.error("Failed to fetch Open Collective data.", error);
+			return {
+				sponsors: [],
+				donations: [],
+			};
+		}),
+		fetchGitHubSponsors().catch(error => {
+			console.error("Failed to fetch GitHub Sponsors data.", error);
+			return {
+				sponsors: [],
+				donations: [],
+			};
+		}),
+		fetchThanksDevData().catch(error => {
+			console.error("Failed to fetch thanks.dev data.", error);
+			return {
+				sponsors: [],
+			};
+		}),
 		fs
 			.readFile(blockedSponsorsFilename, { encoding: "utf8" })
 			.then(data => JSON.parse(data)),

--- a/tools/fetch-sponsors.js
+++ b/tools/fetch-sponsors.js
@@ -108,6 +108,28 @@ function getTierSlug(monthlyDonation) {
 }
 
 /**
+ * Gets the existing sponsors for a given source from the saved sponsors data.
+ * @param {Object} existingSponsorsData The saved sponsors data.
+ * @param {string} source The source to filter by.
+ * @returns {Array} The existing sponsors for the source.
+ */
+function getExistingSponsorsBySource(existingSponsorsData, source) {
+	return Object.values(existingSponsorsData)
+		.flatMap(value => (Array.isArray(value) ? value : []))
+		.filter(sponsor => sponsor.source === source);
+}
+
+/**
+ * Gets the existing donations for a given source from the saved donations data.
+ * @param {Array} existingDonationsData The saved donations data.
+ * @param {string} source The source to filter by.
+ * @returns {Array} The existing donations for the source.
+ */
+function getExistingDonationsBySource(existingDonationsData, source) {
+	return existingDonationsData.filter(donation => donation.source === source);
+}
+
+/**
  * Fetch order data from Open Collective using the GraphQL API.
  * @returns {Promise<{sponsors: Array, donations: Array}>} An promise that resolves to an object with two properties:
  *  - `sponsors` (Array): List of sponsors
@@ -466,6 +488,20 @@ async function fetchThanksDevData() {
 //-----------------------------------------------------------------------------
 
 (async () => {
+	const [existingSponsorsData, existingDonationsData, blockedSponsors] =
+		await Promise.all([
+			fs
+				.readFile(sponsorsFilename, { encoding: "utf8" })
+				.then(data => JSON.parse(data)),
+			fs
+				.readFile(donationsFilename, { encoding: "utf8" })
+				.then(data => JSON.parse(data)),
+			fs
+				.readFile(blockedSponsorsFilename, { encoding: "utf8" })
+				.then(data => JSON.parse(data)),
+		]);
+	let hadSourceFetchFailure = false;
+
 	const [
 		{
 			sponsors: openCollectiveSponsors,
@@ -473,31 +509,45 @@ async function fetchThanksDevData() {
 		},
 		{ sponsors: githubSponsors, donations: githubDonations },
 		{ sponsors: thanksDevSponsors },
-		blockedSponsors,
 	] = await Promise.all([
 		fetchOpenCollectiveData().catch(error => {
+			hadSourceFetchFailure = true;
 			console.error("Failed to fetch Open Collective data.", error);
 			return {
-				sponsors: [],
-				donations: [],
+				sponsors: getExistingSponsorsBySource(
+					existingSponsorsData,
+					"opencollective",
+				),
+				donations: getExistingDonationsBySource(
+					existingDonationsData,
+					"opencollective",
+				),
 			};
 		}),
 		fetchGitHubSponsors().catch(error => {
+			hadSourceFetchFailure = true;
 			console.error("Failed to fetch GitHub Sponsors data.", error);
 			return {
-				sponsors: [],
-				donations: [],
+				sponsors: getExistingSponsorsBySource(
+					existingSponsorsData,
+					"github",
+				),
+				donations: getExistingDonationsBySource(
+					existingDonationsData,
+					"github",
+				),
 			};
 		}),
 		fetchThanksDevData().catch(error => {
+			hadSourceFetchFailure = true;
 			console.error("Failed to fetch thanks.dev data.", error);
 			return {
-				sponsors: [],
+				sponsors: getExistingSponsorsBySource(
+					existingSponsorsData,
+					"thanks.dev",
+				),
 			};
 		}),
-		fs
-			.readFile(blockedSponsorsFilename, { encoding: "utf8" })
-			.then(data => JSON.parse(data)),
 	]);
 
 	const sponsors = openCollectiveSponsors
@@ -589,4 +639,10 @@ async function fetchThanksDevData() {
 	await fs.writeFile(donationsFilename, JSON.stringify(donations, null, 4), {
 		encoding: "utf8",
 	});
+
+	if (hadSourceFetchFailure) {
+		throw new Error(
+			"Sponsor data fetch completed with one or more source failures.",
+		);
+	}
 })();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes the sponsor data fetch flow so a failure from one upstream source does not cause the entire `fetch:sponsors` script to fail.

#### What changes did you make? (Give an overview)

Updated `tools/fetch-sponsors.js` so the Open Collective, GitHub Sponsors, and thanks.dev fetches each handle their own failure during the `Promise.all()` call. If one source rejects, the script now logs the error and falls back to empty data for that source, allowing the rest of the sponsor data to still be written.


#### Related Issues

Fixes #949

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
