### PR TITLE
fix: correctly guard "Fix All" when no fixable messages

### DIFF
--- a/src/playground/app.jsx
+++ b/src/playground/app.jsx
@@ -252,7 +252,7 @@ const App = () => {
 
 	const onFixAll = () => {
 		const hasFixableMessages = messages.filter(message => message.fix);
-		if (!hasFixableMessages) {
+		if (!hasFixableMessages.length) {
 			return;
 		}
 

--- a/src/playground/app.jsx
+++ b/src/playground/app.jsx
@@ -251,8 +251,8 @@ const App = () => {
 	};
 
 	const onFixAll = () => {
-		const hasFixableMessages = messages.filter(message => message.fix);
-		if (!hasFixableMessages.length) {
+		const hasFixableMessages = messages.some(message => message.fix);
+		if (!hasFixableMessages) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fixes a logic bug in the playground's "Fix All" action so it correctly detects when there are no auto-fixable ESLint messages and returns early. Previously the guard was ineffective, causing an unnecessary call to `linter.verifyAndFix()` on every click even when nothing was fixable.

#### What changes did you make? (Give an overview)

Updated app.jsx: replaced `filter` with `some`

Before
```
const hasFixableMessages = messages.filter(message => message.fix)
 ```
 
 
After: 
```
const hasFixableMessages = messages.some(message => message.fix)
```



#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
