### PR TITLE
fix: open playground rule docs in a new tab

### DIFF
--- a/src/playground/components/configuration.jsx
+++ b/src/playground/components/configuration.jsx
@@ -610,6 +610,8 @@ export default function Configuration({
 														rulesMeta[ruleName].docs
 															.url
 													}
+													target="_blank"
+													rel="noreferrer"
 												>
 													{`${ruleName} ${rulesMeta[ruleName].deprecated ? "(deprecated)" : ""}`}
 												</a>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates the playground so that clicking an added rule name opens that rule’s documentation in a new tab.

#### What changes did you make? (Give an overview)

Added `target="_blank"` and `rel="noreferrer"` to the added rule documentation links.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
