### PR TITLE
fix: use `find()` for single-value playground selects

### DIFF
--- a/src/playground/components/configuration.jsx
+++ b/src/playground/components/configuration.jsx
@@ -353,7 +353,7 @@ export default function Configuration({
 									isSearchable={false}
 									styles={customStyles}
 									theme={theme => customTheme(theme)}
-									value={ECMAVersionsOptions.filter(
+									value={ECMAVersionsOptions.find(
 										ecmaVersion =>
 											ecmaVersion.value ===
 											(options.languageOptions
@@ -387,7 +387,7 @@ export default function Configuration({
 								isSearchable={false}
 								styles={customStyles}
 								theme={theme => customTheme(theme)}
-								value={sourceTypeOptions.filter(
+								value={sourceTypeOptions.find(
 									sourceTypeOption =>
 										sourceTypeOption.value ===
 										(options.languageOptions?.sourceType ||
@@ -476,7 +476,7 @@ export default function Configuration({
 								isSearchable={false}
 								styles={customStyles}
 								theme={theme => customTheme(theme)}
-								value={ESLintParserOptions.filter(
+								value={ESLintParserOptions.find(
 									eslintParser =>
 										eslintParser.value ===
 										(options.languageOptions?.parser ||


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR aligns the playground configuration selects with the `react-select` API for single-value selects. The existing code used `.filter()` for some single-select `value` props, which returns an array and is better suited to `isMulti` selects.

#### What changes did you make? (Give an overview)

Updated the single-value `react-select` fields to use `.find()` instead of `.filter()`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
