### PR TITLE
fix: prevent duplicate listeners and implicit global var in nav script

### DIFF
--- a/src/assets/js/components-index.js
+++ b/src/assets/js/components-index.js
@@ -1,7 +1,6 @@
 (function () {
 	var index_trigger = document.getElementById("js-index-toggle"),
 		index = document.getElementById("js-index-list"),
-		body = document.getElementsByTagName("body")[0],
 		open = false;
 
 	if (matchMedia) {
@@ -30,6 +29,8 @@
 		index_trigger.removeAttribute("hidden");
 		index_trigger.setAttribute("aria-expanded", "false");
 		index.setAttribute("data-open", "false");
+		open = false;
+		index_trigger.removeEventListener("click", toggleindex, false);
 		index_trigger.addEventListener("click", toggleindex, false);
 	}
 })();

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1,7 +1,6 @@
 (function () {
 	var nav_trigger = document.getElementById("nav-toggle"),
 		nav = document.getElementById("nav-list"),
-		body = document.getElementsByTagName("body")[0],
 		open = false;
 
 	if (matchMedia) {
@@ -16,11 +15,15 @@
 			nav.setAttribute("data-open", "false");
 			nav_trigger.removeAttribute("hidden");
 			nav_trigger.setAttribute("aria-expanded", "false");
+			open = false;
+			nav_trigger.removeEventListener("click", togglenav, false);
 			nav_trigger.addEventListener("click", togglenav, false);
 		} else {
 			nav.setAttribute("data-open", "true");
 			nav_trigger.setAttribute("hidden", "");
 			nav_trigger.setAttribute("aria-expanded", "true");
+			open = true;
+			nav_trigger.removeEventListener("click", togglenav, false);
 		}
 	}
 
@@ -47,7 +50,7 @@
 		logo_theme_buttons.removeAttribute("hidden");
 		logo_theme_btn.forEach(button => {
 			button.addEventListener("click", function () {
-				btn_theme = button.getAttribute("data-brand-theme");
+				const btn_theme = button.getAttribute("data-brand-theme");
 				unsetOtherButtons();
 				button.setAttribute("aria-pressed", "true");
 				logo_container.setAttribute("data-brand-theme", btn_theme);
@@ -56,10 +59,12 @@
 	}
 
 	function unsetOtherButtons() {
-		currentButton = document.querySelector(
+		const currentButton = document.querySelector(
 			'.brand__logo__colors__btn[aria-pressed="true"]',
 		);
-		currentButton.setAttribute("aria-pressed", "false");
+		if (currentButton) {
+			currentButton.setAttribute("aria-pressed", "false");
+		}
 	}
 })();
 
@@ -82,7 +87,7 @@
 
 			select.addEventListener("change", function () {
 				var selected = this.options[this.selectedIndex];
-				url = selected.getAttribute("data-url");
+				const url = selected.getAttribute("data-url");
 
 				window.location.href = url;
 			});

--- a/src/assets/js/slider.js
+++ b/src/assets/js/slider.js
@@ -295,7 +295,6 @@ var util = {
 					"click",
 					e => {
 						e.preventDefault();
-						e.preventDefault();
 						selectedDot = index;
 						currentIndex = selectedDot;
 						focusCurrentDot();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Fix a couple of small bugs and clean up some code in the nav scripts:

1. After the user opens the mobile nav, resizes to desktop, then resizes back to mobile, the internal open flag drifts out of sync with the DOM's data-open attribute. The next click on the toggle then closes the (already-closed) menu instead of opening it, so the user has to click twice.

2. Three variables (btn_theme, currentButton, url) were being assigned without a declaration keyword. Because the scripts aren't in strict mode, those assignments leak onto window as implicit globals.

3. A leftover body variable was declared but never used.

#### What changes did you make? (Give an overview)
1. Removed the unused body variable in main.js and components-index.js.

2. In WidthChange / initIndex, reset the open flag to match the data-open attribute whenever the viewport crosses the breakpoint, so the toggle behaves correctly after resizing.

3. Added missing const declarations for btn_theme, currentButton, and url to prevent implicit globals.

4. Defensive checks - Added a null guard in unsetOtherButtons in case no button has aria-pressed="true" when it's called and Added removeEventListener calls before re-attaching the click handler

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
