### PR TITLE
fix: align fold gutter markers

### DIFF
--- a/src/playground/components/code-editor.jsx
+++ b/src/playground/components/code-editor.jsx
@@ -1,12 +1,22 @@
 import { useImperativeHandle, useMemo, useRef } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { javascript, esLint } from "@codemirror/lang-javascript";
+import { foldGutter } from "@codemirror/language";
 import { linter } from "../utils/codemirror-linter-extension";
 import {
 	ESLintPlaygroundTheme,
 	ESLintPlaygroundHighlightStyle,
 } from "../utils/codemirror-theme";
 import "../scss/editor.scss";
+
+const foldGutterExtension = foldGutter({
+	closedText: "▸",
+	openText: "▾",
+});
+
+const basicSetup = {
+	foldGutter: false,
+};
 
 export default function CodeEditor({
 	codeValue,
@@ -27,6 +37,7 @@ export default function CodeEditor({
 						.jsx,
 				),
 			}),
+			foldGutterExtension,
 			ESLintPlaygroundTheme,
 			ESLintPlaygroundHighlightStyle,
 		],
@@ -69,6 +80,7 @@ export default function CodeEditor({
 			onChange={value => {
 				onUpdate(value);
 			}}
+			basicSetup={basicSetup}
 		/>
 	);
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Similar to https://github.com/eslint/code-explorer/pull/422, this PR fixes the fold/unfold marker alignment in the CodeMirror gutter. The default unfolded marker was visually off-center next to the line number, so this updates the marker glyphs to use better-aligned triangle characters.

#### What changes did you make? (Give an overview)

- Added a custom CodeMirror `foldGutter` extension using `▸` for folded lines and `▾` for unfolded lines.
- Disabled the default fold gutter from `basicSetup` to avoid rendering duplicate fold controls.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
