### PR TITLE
feat: add toggle nav bar for no-js mode

### DIFF
--- a/src/_includes/components/navigation.html
+++ b/src/_includes/components/navigation.html
@@ -9,7 +9,7 @@
             </svg>
         </button>
     </div>
-    <ul id="nav-list">
+    <ul id="nav-list" class="nav-list-with-js">
         {% for item in site.navigation %}
         <li>
             {% set itemLink = links[item.link] %}
@@ -18,4 +18,23 @@
         </li>
         {% endfor %}
     </ul>
+    <details class="nav-no-js">
+        <summary class="nav-toggle-no-js">
+            <svg width="20" height="20" viewBox="20 20 60 60">
+                <path id="ham-top"    d="M30,37 L70,37 Z" stroke="currentColor"></path>
+                <path id="ham-middle" d="M30,50 L70,50 Z" stroke="currentColor"></path>
+                <path id="ham-bottom" d="M30,63 L70,63 Z" stroke="currentColor"></path>
+            </svg>
+        </summary>
+
+        <ul id="nav-list">
+            {% for item in site.navigation %}
+            <li>
+                {% set itemLink = links[item.link] %}
+                <a href="{{ itemLink }}" {{ helpers.getLinkActiveState(itemLink,
+                page.url) | safe }} {% if item.target %}target="_blank"{% endif %}>{{ item.text }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </details>
 </nav>

--- a/src/assets/scss/components/navigation.scss
+++ b/src/assets/scss/components/navigation.scss
@@ -131,3 +131,55 @@
 		display: block !important;
 	}
 }
+
+.nav-no-js {
+	display: none;
+}
+
+.nav-toggle-no-js svg {
+	width: 40px;
+	height: 40px;
+	color: var(--headings-color);
+	fill: none;
+	stroke-width: 4;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+@media (max-width: 1023px) {
+	html.no-js {
+		.nav-list-with-js {
+			display: none;
+		}
+
+		.nav-no-js {
+			display: block;
+		}
+
+		.nav-toggle-no-js {
+			position: absolute;
+			top: 70px;
+			right: 17px;
+			list-style: none;
+			cursor: pointer;
+		}
+
+		.flexer {
+			position: relative;
+			right: 50px;
+		}
+	}
+}
+
+@media (min-width: 860px) {
+	html.no-js .nav-toggle-no-js {
+		top: 49px;
+		right: 21px;
+	}
+}
+
+@media (max-width: 456px) {
+	html.no-js .nav-toggle-no-js {
+		top: 91px;
+	}
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To add a toggle navbar for mobile size in no-js mode, as right now it is always open in no-js mode.

#### What changes did you make? (Give an overview)
Added a `details` element to make the navbar toggle in no-js mode for small screen sizes and also to make the behavior consistent with docs site.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
