### PR TITLE
fix: border radius of suggestion alert

### DIFF
--- a/src/assets/scss/components/alert.scss
+++ b/src/assets/scss/components/alert.scss
@@ -239,5 +239,9 @@
 			border: none;
 			border-radius: 0 0 var(--border-radius) 0;
 		}
+
+		&:only-of-type {
+			border-radius: 0 0 var(--border-radius) var(--border-radius);
+		}
 	}
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To fix the border radius of the suggestion alert, when there is only one suggestion, as right now, the suggestion alert is looking like this when hovering (no border radius in the bottom left):
<img width="91" height="97" alt="Screenshot 2026-05-29 224808" src="https://github.com/user-attachments/assets/cb1f6ff6-398f-46c9-9208-4af97d8bce93" />
<img width="417" height="125" alt="Screenshot 2026-05-29 154927" src="https://github.com/user-attachments/assets/3fc6f48f-b1e4-4f9e-8b68-a3f94a579ed8" />

#### What changes did you make? (Give an overview)
Applied border radius to the alert when there is only one suggestion.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
