### PR TITLE
feat: add disable to alert with suggestions

### DIFF
--- a/src/assets/scss/components/alert.scss
+++ b/src/assets/scss/components/alert.scss
@@ -139,6 +139,10 @@
 	gap: 0.75rem;
 	min-width: 6rem;
 
+	&.suggestion-disable-btn {
+		border-radius: 0 var(--border-radius) 0 0;
+	}
+
 	&:last-child {
 		border-radius: 0 var(--border-radius) var(--border-radius) 0;
 	}

--- a/src/playground/app.jsx
+++ b/src/playground/app.jsx
@@ -315,9 +315,7 @@ const App = () => {
 	);
 
 	const filteredMessages = messages.filter(
-		message =>
-			!message.suggestions &&
-			(message.fix || options.rules[message.ruleId]),
+		message => message.fix || options.rules[message.ruleId],
 	);
 
 	return (

--- a/src/playground/components/alert.jsx
+++ b/src/playground/components/alert.jsx
@@ -50,6 +50,21 @@ export default function Alert({
 		suggestions,
 	} = message;
 
+	const handleDisableRule = () => {
+		const newRules = { ...options.rules };
+		delete newRules[ruleId];
+
+		setRulesWithInvalidConfigs(
+			new Set(
+				[...rulesWithInvalidConfigs].filter(rule => rule !== ruleId),
+			),
+		);
+		onUpdate({
+			...options,
+			rules: newRules,
+		});
+	};
+
 	return (
 		<article aria-roledescription={type} className={`alert alert--${type}`}>
 			<div className="alert__content">
@@ -130,6 +145,14 @@ export default function Alert({
 							</g>
 						</svg>
 					</button>
+					{options.rules[ruleId] && (
+						<button
+							onClick={handleDisableRule}
+							className="alert__fix-btn suggestion-disable-btn"
+						>
+							Disable
+						</button>
+					)}
 					<ul
 						className="alert__fix-options"
 						role="menu"
@@ -163,22 +186,7 @@ export default function Alert({
 					)}
 					{options.rules[ruleId] && (
 						<button
-							onClick={() => {
-								const newRules = { ...options.rules };
-								delete newRules[ruleId];
-
-								setRulesWithInvalidConfigs(
-									new Set(
-										[...rulesWithInvalidConfigs].filter(
-											rule => rule !== ruleId,
-										),
-									),
-								);
-								onUpdate({
-									...options,
-									rules: newRules,
-								});
-							}}
+							onClick={handleDisableRule}
 							className="alert__fix-btn"
 						>
 							Disable

--- a/src/playground/components/alerts-action-bar.jsx
+++ b/src/playground/components/alerts-action-bar.jsx
@@ -7,7 +7,7 @@ export default function AlertsActionBar({
 }) {
 	const hasFixableMessages = messages.some(message => message.fix);
 	const hasDisableableMessages = messages.some(
-		message => !message.suggestions && options.rules[message.ruleId],
+		message => options.rules[message.ruleId],
 	);
 
 	let description = "";
@@ -26,14 +26,12 @@ export default function AlertsActionBar({
 		const updatedOptions = { ...options };
 
 		messages.forEach(message => {
-			if (!message.suggestions) {
-				delete updatedOptions.rules[message.ruleId];
-				setRulesWithInvalidConfigs(prev => {
-					const updatedSet = new Set(prev);
-					updatedSet.delete(message.ruleId);
-					return updatedSet;
-				});
-			}
+			delete updatedOptions.rules[message.ruleId];
+			setRulesWithInvalidConfigs(prev => {
+				const updatedSet = new Set(prev);
+				updatedSet.delete(message.ruleId);
+				return updatedSet;
+			});
 		});
 		onUpdate(updatedOptions);
 	};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Right now, alerts with suggestions in the playground don't have a disable button with them, as other alerts have.

<img width="1324" height="174" alt="Screenshot 2026-06-08 131313" src="https://github.com/user-attachments/assets/53a9d4e2-3c27-442e-a772-3178936d6f29" />


#### What changes did you make? (Give an overview)
Added a disable button to alerts with suggestions, to disable the rule from the config in the right sidebar.

<img width="1335" height="131" alt="Screenshot 2026-06-08 130732" src="https://github.com/user-attachments/assets/8e0c9cf9-98d9-4c54-91bd-d2975cc8c8ae" />
<img width="1324" height="265" alt="Screenshot 2026-06-08 130801" src="https://github.com/user-attachments/assets/a203967c-a08d-42fc-840c-befe840ac1ea" />

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
I didn't find any discussion about not having a disable button in the alert bar with suggestions in https://github.com/eslint/eslint.org/issues/548 and https://github.com/eslint/eslint.org/pull/546