### PR TITLE
feat: blog: Automating ESLint migrations with Codemod

### DIFF
--- a/src/_data/all_authors.json
+++ b/src/_data/all_authors.json
@@ -241,7 +241,7 @@
         "title": "Guest Author",
         "website": "https://codemod.com",
         "avatar_url": "https://avatars.githubusercontent.com/u/78109534",
-        "bio": "Building Codemod & codemods... Let's chat! I'd love to hear how we can make your code migration experience better.",
+        "bio": "Co-founder of Codemod",
         "twitter_username": "Alex__Bit",
         "github_username": "alexbit-codemod",
         "location": "Palo Alto, CA"

--- a/src/_data/all_authors.json
+++ b/src/_data/all_authors.json
@@ -234,5 +234,16 @@
         "twitter_username": null,
         "github_username": "yeonjuan",
         "location": "South Korea"
+    },
+    "alexbit-codemod": {
+        "username": "alexbit-codemod",
+        "name": "Alex Bit",
+        "title": "Guest Author",
+        "website": "https://codemod.com",
+        "avatar_url": "https://avatars.githubusercontent.com/u/78109534",
+        "bio": "Building Codemod & codemods... Let's chat! I'd love to hear how we can make your code migration experience better.",
+        "twitter_username": "Alex__Bit",
+        "github_username": "alexbit-codemod",
+        "location": "Palo Alto, CA"
     }
 }

--- a/src/_data/blog-dates.json
+++ b/src/_data/blog-dates.json
@@ -391,7 +391,7 @@
     "2024-05-03-eslint-v9.2.0-released.md": "2024-05-03T20:16:51.000Z",
     "2024-05-09-eslint-compatibility-utilities.md": "2024-05-10T15:04:34.000Z",
     "2024-05-17-eslint-v9.3.0-released.md": "2024-05-17T21:21:38.000Z",
-    "2024-05-31-eslint-configuration-migrator.md": "2026-06-13T13:54:51.954Z",
+    "2024-05-31-eslint-configuration-migrator.md": "2026-06-16T00:36:00.157Z",
     "2024-05-31-eslint-v9.4.0-released.md": "2024-05-31T20:51:35.000Z",
     "2024-06-14-eslint-v9.5.0-released.md": "2024-06-14T19:57:29.000Z",
     "2024-06-28-eslint-v9.6.0-released.md": "2024-06-28T17:54:20.000Z",

--- a/src/_data/blog-dates.json
+++ b/src/_data/blog-dates.json
@@ -365,7 +365,7 @@
     "2023-08-25-eslint-v8.48.0-released.md": "2023-08-25T20:25:23.000Z",
     "2023-09-08-eslint-v8.49.0-released.md": "2023-09-08T20:45:03.000Z",
     "2023-09-22-eslint-v8.50.0-released.md": "2023-09-22T21:19:41.000Z",
-    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2026-06-12T18:37:11.622Z",
+    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2026-06-15T17:35:03.565Z",
     "2023-10-06-eslint-v8.51.0-released.md": "2023-10-06T20:34:34.000Z",
     "2023-10-10-flat-config-rollout-plans.md": "2023-10-25T19:41:37.000Z",
     "2023-10-20-eslint-v8.52.0-released.md": "2023-10-20T21:15:17.000Z",

--- a/src/_data/blog-dates.json
+++ b/src/_data/blog-dates.json
@@ -391,7 +391,7 @@
     "2024-05-03-eslint-v9.2.0-released.md": "2024-05-03T20:16:51.000Z",
     "2024-05-09-eslint-compatibility-utilities.md": "2024-05-10T15:04:34.000Z",
     "2024-05-17-eslint-v9.3.0-released.md": "2024-05-17T21:21:38.000Z",
-    "2024-05-31-eslint-configuration-migrator.md": "2024-05-31T16:06:43.000Z",
+    "2024-05-31-eslint-configuration-migrator.md": "2026-06-13T13:54:51.954Z",
     "2024-05-31-eslint-v9.4.0-released.md": "2024-05-31T20:51:35.000Z",
     "2024-06-14-eslint-v9.5.0-released.md": "2024-06-14T19:57:29.000Z",
     "2024-06-28-eslint-v9.6.0-released.md": "2024-06-28T17:54:20.000Z",

--- a/src/_data/blog-dates.json
+++ b/src/_data/blog-dates.json
@@ -365,7 +365,7 @@
     "2023-08-25-eslint-v8.48.0-released.md": "2023-08-25T20:25:23.000Z",
     "2023-09-08-eslint-v8.49.0-released.md": "2023-09-08T20:45:03.000Z",
     "2023-09-22-eslint-v8.50.0-released.md": "2023-09-22T21:19:41.000Z",
-    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2026-06-15T17:35:03.565Z",
+    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2026-06-22T05:22:37.068Z",
     "2023-10-06-eslint-v8.51.0-released.md": "2023-10-06T20:34:34.000Z",
     "2023-10-10-flat-config-rollout-plans.md": "2023-10-25T19:41:37.000Z",
     "2023-10-20-eslint-v8.52.0-released.md": "2023-10-20T21:15:17.000Z",

--- a/src/_data/blog-dates.json
+++ b/src/_data/blog-dates.json
@@ -365,7 +365,7 @@
     "2023-08-25-eslint-v8.48.0-released.md": "2023-08-25T20:25:23.000Z",
     "2023-09-08-eslint-v8.49.0-released.md": "2023-09-08T20:45:03.000Z",
     "2023-09-22-eslint-v8.50.0-released.md": "2023-09-22T21:19:41.000Z",
-    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2024-06-06T16:38:46.000Z",
+    "2023-09-26-preparing-custom-rules-eslint-v9.md": "2026-06-12T18:37:11.622Z",
     "2023-10-06-eslint-v8.51.0-released.md": "2023-10-06T20:34:34.000Z",
     "2023-10-10-flat-config-rollout-plans.md": "2023-10-25T19:41:37.000Z",
     "2023-10-20-eslint-v8.52.0-released.md": "2023-10-20T21:15:17.000Z",

--- a/src/_includes/partials/author_bios/alexbit-codemod.md
+++ b/src/_includes/partials/author_bios/alexbit-codemod.md
@@ -1,0 +1,1 @@
+Alex Bit is the founder and CEO of [Codemod](https://codemod.com). He works on building tools that make large-scale code migrations faster and more reliable for open source projects and enterprises.

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -293,3 +293,7 @@ The `context.parserPath` property was intended to allow rules to retrieve an ins
 ## Conclusion
 
 ESLint has been around for ten years, and in that time, we have collected some API cruft that we need to clean up in order to prepare ESLint for the next ten years. The API changes described in this post are a necessary step towards enabling ESLint to lint non-JavaScript languages and to better separate core functionality from language-specific functionality. The team spent a lot of time planning this transition point in ESLint's lifecycle and we hope that these changes are just a small inconvenience for the ecosystem. If you need help with, or have questions about, any of what was discussed in this post, please [start a discussion](https://github.com/eslint/eslint/discussions/new) or stop by [Discord](https://eslint.org/chat) to talk with the team.
+
+**Update (2024-06-06):** Added section on `eslint-tranforms`.
+
+**Update (2026-06-19):** Replaced the section on `eslint-transforms` with `@eslint/v8-to-v9-custom-rules`.

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -15,20 +15,58 @@ When ESLint v9.0.0 is released, it will ship with several breaking changes for r
 
 ## Automatically update your rules
 
-Before explaining all of the changes introduced in ESLint v9.0.0, it's helpful to know that most of the changes described in this post can be automatically made using the [`eslint-transforms`](https://www.npmjs.com/package/eslint-transforms) utility. To use the utility, first install it and then run the `v9-rule-migration` transform, like this:
+Before explaining all of the changes introduced in ESLint v9.0.0, it's helpful to know that most of the changes described in this post can be automated using the official [`@eslint/v8-to-v9-custom-rules`](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules) codemod from the [eslint/codemods](https://github.com/eslint/codemods) repository.
+
+Run the codemod against your rule files or directories:
 
 ```shell
-# install the utility
-npm install eslint-transforms -g
-
-# apply the transform to one file
-eslint-transforms v9-rule-migration rule.js
-
-# apply the transform to all files in a directory
-eslint-transforms v9-rule-migration rules/
+npx codemod @eslint/v8-to-v9-custom-rules
 ```
 
-Not every change can be addressed with `eslint-tranforms`, though, so below is a complete list of the API changes and recommended ways to address them.
+**Important:** Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that export functions.
+
+The codemod supports both CommonJS (`module.exports = function (context) { ... }`) and ES Modules (`export default function (context) { ... }`) export styles.
+
+### What the codemod handles
+
+The codemod performs a comprehensive migration of custom ESLint rules from v8 to v9, including:
+
+* **Removed `context` methods** — migrates calls to `sourceCode` equivalents (for example, `context.getSource()` → `sourceCode.getText()`)
+* **Removed `sourceCode.getComments()`** — converts to a combination of `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()`
+* **Removed `CodePath#currentSegments`** — adds code path tracking logic
+* **Function-style rules are no longer supported** — converts to the object format with `meta` and `create`
+
+The codemod also detects fixable rules and adds `fixable: "code"` to `meta`.
+
+Not every change can be fully automated, though. After running the codemod, review your migrated files and consult the sections below for anything that still needs manual attention. For a complete list of breaking changes, see the [ESLint v9 migration guide](/docs/latest/use/migrate-to-9.0.0).
+
+### Manual steps after running the codemod
+
+1. **Review TODO comments.** Search for `TODO` in your migrated files and address each one:
+
+    | TODO comment | Action required |
+    | --- | --- |
+    | `// TODO: Define schema - this rule uses context.options` | Define a proper JSON schema for your rule's options |
+    | `/* TODO: new node param */` | Add the `node` parameter to `getAncestors(node)` or `getScope(node)` |
+    | `/* TODO: new name, node params */` | Update `markVariableAsUsed(name, node)` with the correct parameters |
+
+2. **Fix schemas for rules using options.** If your rule uses `context.options`, you must define the schema manually. The codemod may leave a placeholder like `schema: [] // TODO: Define schema - this rule uses context.options` that you need to replace with a valid JSON schema.
+
+3. **Verify method signature changes.** The codemod replaces these methods automatically, but you need to confirm the `node` parameter is correct:
+
+    | Removed on `context` | Replacement on `SourceCode` |
+    | --- | --- |
+    | `context.getAncestors()` | `sourceCode.getAncestors(node)` |
+    | `context.getScope()` | `sourceCode.getScope(node)` |
+    | `context.markVariableAsUsed(name)` | `sourceCode.markVariableAsUsed(name, node)` |
+    | `context.getDeclaredVariables(node)` | `sourceCode.getDeclaredVariables(node)` |
+    | `context.getSource(node)` | `sourceCode.getText(node)` |
+    | `context.getSourceLines()` | `sourceCode.getLines()` |
+    | `context.getAllComments()` | `sourceCode.getCommentsBefore()`, `getCommentsInside()`, or `getCommentsAfter()` |
+
+4. **Test your custom rules** by running your rule test suite (for example, `npm test`).
+
+Below is a complete list of the API changes and recommended ways to address them manually if you prefer not to use the codemod.
 
 ## `context` methods becoming properties
 
@@ -41,7 +79,7 @@ As we look towards the API we'd like rules for other languages to have, we decid
 |`context.getPhysicalFilename()`|`context.physicalFilename`|
 |`context.getCwd()`|`context.cwd`|
 
-We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. Here's an example that ensures the correct value is used:
+We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. The `@eslint/v8-to-v9-custom-rules` codemod does not cover these changes because they are not removed until ESLint v10.0.0. Here's an example that ensures the correct value is used:
 
 ```js
 module.exports = {
@@ -93,7 +131,7 @@ All of this is to say that we are deprecating all of the code-related methods on
 |`context.getTokensBetween()`|`sourceCode.getTokensBetween()`|
 |`context.parserServices`|`sourceCode.parserServices`|
 
-All of the `context` methods listed in this table will be removed in ESLint v9.0.0, and the replacement methods on `SourceCode` have already been in place for six years, so you should have no problem switching to the new methods. (Yes, we deprecated these and then completely forgot to remove them.)
+All of the `context` methods listed in this table will be removed in ESLint v9.0.0, and the replacement methods on `SourceCode` have already been in place for six years, so you should have no problem switching to the new methods. (Yes, we deprecated these and then completely forgot to remove them.) The `@eslint/v8-to-v9-custom-rules` codemod migrates these method calls automatically.
 
 In addition to the methods in this table, there are several other methods that are also moving but required different method signatures.
 
@@ -101,7 +139,7 @@ In addition to the methods in this table, there are several other methods that a
 
 The `context.getScope()` method is used to retrieve a scope object for the currently-traversed node. This method was always a bit strange because it uses ESLint's internal traversal state to determine which node to use as a reference point to retrieve a scope object. That meant it was both limited, because you couldn't change the reference node, and confusing, because it wasn't always clear what node was being referenced. So, we are deprecating this method and will remove it in ESLint v9.0.0.
 
-We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. For best compatibility, you can check for the presence of this new method to determine which one to use:
+We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. The codemod migrates `context.getScope()` calls but leaves a TODO comment where you need to verify the `node` parameter. For best compatibility, you can check for the presence of this new method to determine which one to use:
 
 ```js
 module.exports = {
@@ -124,7 +162,7 @@ module.exports = {
 
 ### `context.getAncestors()`
 
-The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. Here is an example that checks for the correct method to use:
+The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. The codemod migrates `context.getAncestors()` calls but leaves a TODO comment where you need to verify the `node` parameter. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -147,7 +185,7 @@ module.exports = {
 
 ### `context.getDeclaredVariables(node)`
 
-The `context.getDeclaredVariables(node)` returns all variables declared by the given node (such as in a `let` statement). We are deprecating this method and will remove it in v9.0.0. We are replacing it with `SourceCode#getDeclaredVariables(node)` (added in v8.38.0), which works exactly the same way. Here is an example that checks for the correct method to use:
+The `context.getDeclaredVariables(node)` returns all variables declared by the given node (such as in a `let` statement). We are deprecating this method and will remove it in v9.0.0. We are replacing it with `SourceCode#getDeclaredVariables(node)` (added in v8.38.0), which works exactly the same way. The codemod migrates this call automatically. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -170,7 +208,7 @@ module.exports = {
 
 ### `context.markVariableAsUsed(name)`
 
-The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) Here is an example that checks for the correct method to use:
+The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) The codemod migrates `context.markVariableAsUsed()` calls but leaves a TODO comment where you need to verify the `name` and `node` parameters. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -197,7 +235,7 @@ module.exports = {
 
 A little-known ability of ESLint rules is [analyzing code paths](https://eslint.org/docs/latest/extend/code-path-analysis). ESLint core rules use code path analysis in multiple rules to validate not just what the code looks like but also how the logic flows. This is done through accessing `CodePath` and `CodePathSegment` objects. In doing our research for language plugins, we discovered that `CodePath#currentSegments` actually represents another traversal state that is exposed in rules. Specifically, `CodePath#currentSegments` is an array that grows and shrinks throughout traversal as you encounter different code path segments. Because code path analysis is unique to JavaScript, we can't have the core tracking this traversal state any longer. After evaluating several options, we decided that having an object that represented both code path data and traversal state was undesirable, so we are deprecating `CodePath#currentSegments` and will remove it in v9.0.0. We needed to add two new event handlers, `onUnreachableCodePathSegmentStart` and `onUnreachableCodePathSegmentEnd`, to allow access to the same data (these were added in v8.49.0).
 
-To recreate this data, you'll need to track the traversal state manually, which can be accomplished with the following code:
+To recreate this data, you'll need to track the traversal state manually, which can be accomplished with the following code. The `@eslint/v8-to-v9-custom-rules` codemod can add this tracking logic for you, but you should verify the result matches your rule's needs:
 
 ```js
 module.exports = {
@@ -253,12 +291,10 @@ We have already made this change in all of the ESLint core rules to validate tha
 
 ## `context` properties: `parserOptions` and `parserPath` being removed
 
-Additionally, the `context.parserOptions` and `context.parserPath` properties are deprecated and will be removed in v10.0.0 (not v9.0.0). There is a new `context.languageOptions` property that allows rules to access similar data as `context.parserOptions`. In general, though, rules should not depend on information either in `context.parserOptions` or `context.languageOptions` to determine how they should behave.
+Additionally, the `context.parserOptions` and `context.parserPath` properties are deprecated and will be removed in v10.0.0 (not v9.0.0). The `@eslint/v8-to-v9-custom-rules` codemod does not cover these changes because they are not removed until ESLint v10.0.0. There is a new `context.languageOptions` property that allows rules to access similar data as `context.parserOptions`. In general, though, rules should not depend on information either in `context.parserOptions` or `context.languageOptions` to determine how they should behave.
 
 The `context.parserPath` property was intended to allow rules to retrieve an instance of the parser that ESLint is using via `require()`. However, the new flat config system does not know the location of the parser module to load, so we are unable to provide this data. Further, because the JavaScript ecosystem is moving to ESM, any value returned from this property will not work with `import()`. This property was added early on in ESLint's life and we generally recommend that rules not try to further parse JavaScript code inside of them. If necessary, you can use `context.languageOptions.parser` to access the parser ESLint is using.
 
 ## Conclusion
 
 ESLint has been around for ten years, and in that time, we have collected some API cruft that we need to clean up in order to prepare ESLint for the next ten years. The API changes described in this post are a necessary step towards enabling ESLint to lint non-JavaScript languages and to better separate core functionality from language-specific functionality. The team spent a lot of time planning this transition point in ESLint's lifecycle and we hope that these changes are just a small inconvenience for the ecosystem. If you need help with, or have questions about, any of what was discussed in this post, please [start a discussion](https://github.com/eslint/eslint/discussions/new) or stop by [Discord](https://eslint.org/chat) to talk with the team.
-
-**Update (2024-06-06):** Added section on `eslint-tranforms`.

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -11,57 +11,26 @@ categories:
   - API Changes
 ---
 
+**Update:** We have partnered with Codemod to make migration easier. Read about the new approach in [this blog post](#TODO-final-url).
+
 When ESLint v9.0.0 is released, it will ship with several breaking changes for rule authors. These changes are necessary as part of the work to implement [language plugins](https://github.com/eslint/rfcs/blob/main/designs/2022-languages/README.md), which gives ESLint first-class support for linting languages other than JavaScript. We've had to make these changes because ESLint has, from the start, assumed that it would only ever be used to lint JavaScript. As such, there wasn't a lot of thought put into where methods that rules used to interact with source code should live. When revisiting the API for the language plugins work we found that the inconsistencies we were able to live with in a JavaScript-only world will not work in a language-agnostic ESLint core.
 
 ## Automatically update your rules
 
-Before explaining all of the changes introduced in ESLint v9.0.0, it's helpful to know that most of the changes described in this post can be automated using the official [`@eslint/v8-to-v9-custom-rules`](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules) codemod from the [eslint/codemods](https://github.com/eslint/codemods) repository.
-
-Run the codemod against your rule files or directories:
+Before explaining all of the changes introduced in ESLint v9.0.0, it's helpful to know that most of the changes described in this post can be automatically made using the [`eslint-transforms`](https://www.npmjs.com/package/eslint-transforms) utility. To use the utility, first install it and then run the `v9-rule-migration` transform, like this:
 
 ```shell
-npx codemod @eslint/v8-to-v9-custom-rules
+# install the utility
+npm install eslint-transforms -g
+
+# apply the transform to one file
+eslint-transforms v9-rule-migration rule.js
+
+# apply the transform to all files in a directory
+eslint-transforms v9-rule-migration rules/
 ```
 
-**Important:** Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that export functions.
-
-The codemod supports CommonJS (`module.exports = function (context) { ... }`), ES Modules (`export default function (context) { ... }`), indirect exports (`function rule() {}` and `module.exports = rule`), higher-order wrappers such as `wrapRule(function (context) { ... })`, and rules created with `@typescript-eslint/utils` `RuleCreator`.
-
-### What the codemod handles
-
-The codemod performs a comprehensive migration of custom ESLint rules from v8 to v9, including:
-
-* **Removed `context` methods** — migrates calls to `sourceCode` equivalents (for example, `context.getSource()` → `sourceCode.getText()`)
-* **Removed `context.getComments()`** — converts node-specific calls to `getCommentsBefore/Inside/After(node)`
-* **Removed `CodePath#currentSegments`** — adds code path tracking logic
-* **Function-style rules are no longer supported** — converts to the object format with `meta` and `create`
-
-The codemod also moves `module.exports.schema` into `meta`, converts old-style `context.report(node, message)` calls to object format, detects fixable rules, and adds `fixable: "code"` to `meta`.
-
-Not every change can be fully automated, though. After running the codemod, review your migrated files and consult the sections below for anything that still needs manual attention. For a complete list of breaking changes, see the [ESLint v9 migration guide](/docs/latest/use/migrate-to-9.0.0).
-
-### Manual steps after running the codemod
-
-1. **Review TODO comments.** Search for `TODO` in your migrated files and address each one:
-
-    | TODO comment | Action required |
-    | --- | --- |
-    | `// TODO: Define schema - this rule uses context.options` | Define a proper JSON schema for your rule's options |
-
-2. **Fix schemas for rules using options.** If your rule uses `context.options`, you must define the schema manually. The codemod may leave a placeholder like `schema: [] // TODO: Define schema - this rule uses context.options` that you need to replace with a valid JSON schema.
-
-3. **Review comment method changes.** `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()` require a `node` argument, and no-argument `context.getComments()` calls should use `sourceCode.getAllComments()`:
-
-    | Removed on `context` | Replacement on `SourceCode` |
-    | --- | --- |
-    | `context.getAllComments()` | `sourceCode.getAllComments()` |
-    | `context.getComments(node)` | `sourceCode.getCommentsBefore/Inside/After(node)` |
-
-4. **Review skipped higher-order wrappers.** If a wrapper passes configuration as the second argument (for example, `wrapRule(rule, config)`), confirm whether any manual migration is needed.
-
-5. **Test your custom rules** by running your rule test suite (for example, `npm test`).
-
-Below is a complete list of the API changes and recommended ways to address them manually if you prefer not to use the codemod.
+Not every change can be addressed with `eslint-tranforms`, though, so below is a complete list of the API changes and recommended ways to address them.
 
 ## `context` methods becoming properties
 
@@ -74,7 +43,7 @@ As we look towards the API we'd like rules for other languages to have, we decid
 |`context.getPhysicalFilename()`|`context.physicalFilename`|
 |`context.getCwd()`|`context.cwd`|
 
-We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. The `@eslint/v8-to-v9-custom-rules` codemod handles these changes with fallbacks. Here's an example that ensures the correct value is used:
+We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. Here's an example that ensures the correct value is used:
 
 ```js
 module.exports = {
@@ -126,7 +95,7 @@ All of this is to say that we are deprecating all of the code-related methods on
 |`context.getTokensBetween()`|`sourceCode.getTokensBetween()`|
 |`context.parserServices`|`sourceCode.parserServices`|
 
-All of the `context` methods listed in this table will be removed in ESLint v9.0.0, and the replacement methods on `SourceCode` have already been in place for six years, so you should have no problem switching to the new methods. (Yes, we deprecated these and then completely forgot to remove them.) The `@eslint/v8-to-v9-custom-rules` codemod migrates these method calls automatically.
+All of the `context` methods listed in this table will be removed in ESLint v9.0.0, and the replacement methods on `SourceCode` have already been in place for six years, so you should have no problem switching to the new methods. (Yes, we deprecated these and then completely forgot to remove them.)
 
 In addition to the methods in this table, there are several other methods that are also moving but required different method signatures.
 
@@ -134,7 +103,7 @@ In addition to the methods in this table, there are several other methods that a
 
 The `context.getScope()` method is used to retrieve a scope object for the currently-traversed node. This method was always a bit strange because it uses ESLint's internal traversal state to determine which node to use as a reference point to retrieve a scope object. That meant it was both limited, because you couldn't change the reference node, and confusing, because it wasn't always clear what node was being referenced. So, we are deprecating this method and will remove it in ESLint v9.0.0.
 
-We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. The codemod migrates `context.getScope()` calls directly to `sourceCode.getScope(node)`. For best compatibility, you can check for the presence of this new method to determine which one to use:
+We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. For best compatibility, you can check for the presence of this new method to determine which one to use:
 
 ```js
 module.exports = {
@@ -157,7 +126,7 @@ module.exports = {
 
 ### `context.getAncestors()`
 
-The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. The codemod migrates `context.getAncestors()` calls with a compatibility fallback. Here is an example that checks for the correct method to use:
+The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -180,7 +149,7 @@ module.exports = {
 
 ### `context.getDeclaredVariables(node)`
 
-The `context.getDeclaredVariables(node)` returns all variables declared by the given node (such as in a `let` statement). We are deprecating this method and will remove it in v9.0.0. We are replacing it with `SourceCode#getDeclaredVariables(node)` (added in v8.38.0), which works exactly the same way. The codemod migrates this call automatically. Here is an example that checks for the correct method to use:
+The `context.getDeclaredVariables(node)` returns all variables declared by the given node (such as in a `let` statement). We are deprecating this method and will remove it in v9.0.0. We are replacing it with `SourceCode#getDeclaredVariables(node)` (added in v8.38.0), which works exactly the same way. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -203,7 +172,7 @@ module.exports = {
 
 ### `context.markVariableAsUsed(name)`
 
-The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) The codemod migrates `context.markVariableAsUsed()` calls automatically. Here is an example that checks for the correct method to use:
+The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -230,7 +199,7 @@ module.exports = {
 
 A little-known ability of ESLint rules is [analyzing code paths](https://eslint.org/docs/latest/extend/code-path-analysis). ESLint core rules use code path analysis in multiple rules to validate not just what the code looks like but also how the logic flows. This is done through accessing `CodePath` and `CodePathSegment` objects. In doing our research for language plugins, we discovered that `CodePath#currentSegments` actually represents another traversal state that is exposed in rules. Specifically, `CodePath#currentSegments` is an array that grows and shrinks throughout traversal as you encounter different code path segments. Because code path analysis is unique to JavaScript, we can't have the core tracking this traversal state any longer. After evaluating several options, we decided that having an object that represented both code path data and traversal state was undesirable, so we are deprecating `CodePath#currentSegments` and will remove it in v9.0.0. We needed to add two new event handlers, `onUnreachableCodePathSegmentStart` and `onUnreachableCodePathSegmentEnd`, to allow access to the same data (these were added in v8.49.0).
 
-To recreate this data, you'll need to track the traversal state manually, which can be accomplished with the following code. The `@eslint/v8-to-v9-custom-rules` codemod can add this tracking logic for you, but you should verify the result matches your rule's needs:
+To recreate this data, you'll need to track the traversal state manually, which can be accomplished with the following code:
 
 ```js
 module.exports = {
@@ -286,7 +255,7 @@ We have already made this change in all of the ESLint core rules to validate tha
 
 ## `context` properties: `parserOptions` and `parserPath` being removed
 
-Additionally, the `context.parserOptions` and `context.parserPath` properties are deprecated and will be removed in v10.0.0 (not v9.0.0). The `@eslint/v8-to-v9-custom-rules` codemod does not cover these changes because they are not removed until ESLint v10.0.0. There is a new `context.languageOptions` property that allows rules to access similar data as `context.parserOptions`. In general, though, rules should not depend on information either in `context.parserOptions` or `context.languageOptions` to determine how they should behave.
+Additionally, the `context.parserOptions` and `context.parserPath` properties are deprecated and will be removed in v10.0.0 (not v9.0.0). There is a new `context.languageOptions` property that allows rules to access similar data as `context.parserOptions`. In general, though, rules should not depend on information either in `context.parserOptions` or `context.languageOptions` to determine how they should behave.
 
 The `context.parserPath` property was intended to allow rules to retrieve an instance of the parser that ESLint is using via `require()`. However, the new flat config system does not know the location of the parser module to load, so we are unable to provide this data. Further, because the JavaScript ecosystem is moving to ESM, any value returned from this property will not work with `import()`. This property was added early on in ESLint's life and we generally recommend that rules not try to further parse JavaScript code inside of them. If necessary, you can use `context.languageOptions.parser` to access the parser ESLint is using.
 
@@ -295,5 +264,3 @@ The `context.parserPath` property was intended to allow rules to retrieve an ins
 ESLint has been around for ten years, and in that time, we have collected some API cruft that we need to clean up in order to prepare ESLint for the next ten years. The API changes described in this post are a necessary step towards enabling ESLint to lint non-JavaScript languages and to better separate core functionality from language-specific functionality. The team spent a lot of time planning this transition point in ESLint's lifecycle and we hope that these changes are just a small inconvenience for the ecosystem. If you need help with, or have questions about, any of what was discussed in this post, please [start a discussion](https://github.com/eslint/eslint/discussions/new) or stop by [Discord](https://eslint.org/chat) to talk with the team.
 
 **Update (2024-06-06):** Added section on `eslint-tranforms`.
-
-**Update (2026-06-19):** Replaced the section on `eslint-transforms` with `@eslint/v8-to-v9-custom-rules`.

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -62,7 +62,7 @@ Not every change can be fully automated, though. After running the codemod, revi
     | `context.getDeclaredVariables(node)` | `sourceCode.getDeclaredVariables(node)` |
     | `context.getSource(node)` | `sourceCode.getText(node)` |
     | `context.getSourceLines()` | `sourceCode.getLines()` |
-    | `context.getAllComments()` | `sourceCode.getCommentsBefore()`, `getCommentsInside()`, or `getCommentsAfter()` |
+    | `context.getComments()` | `sourceCode.getCommentsBefore()`, `getCommentsInside()`, or `getCommentsAfter()` |
 
 4. **Test your custom rules** by running your rule test suite (for example, `npm test`).
 

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -108,7 +108,7 @@ All of this is to say that we are deprecating all of the code-related methods on
 |`context.getSourceLines()`|`sourceCode.getLines()`|
 |`context.getAllComments()`|`sourceCode.getAllComments()`|
 |`context.getNodeByRangeIndex()`|`sourceCode.getNodeByRangeIndex()`|
-|`context.getComments(node)`|`sourceCode.getCommentsBefore(node)`, `sourceCode.getCommentsAfter(node)`, `sourceCode.getCommentsInside(node)`|
+|`context.getComments()`|`sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, `sourceCode.getCommentsInside()`|
 |`context.getCommentsBefore()`|`sourceCode.getCommentsBefore()`|
 |`context.getCommentsAfter()`|`sourceCode.getCommentsAfter()`|
 |`context.getCommentsInside()`|`sourceCode.getCommentsInside()`|
@@ -240,10 +240,10 @@ module.exports = {
     create(context) {
 
         // tracks the code path we are currently in
-        let newCurrentCodePath;
+        let currentCodePath;
 
         // tracks the segments we've traversed in the current code path
-        let newCurrentSegments;
+        let currentSegments;
 
         // tracks all current segments for all open paths
         const allCurrentSegments = [];
@@ -251,30 +251,30 @@ module.exports = {
         return {
 
             onCodePathStart(codePath) {
-                newCurrentCodePath = codePath;
-                allCurrentSegments.push(newCurrentSegments);
-                newCurrentSegments = new Set();
+                currentCodePath = codePath;
+                allCurrentSegments.push(currentSegments);
+                currentSegments = new Set();
             },
 
             onCodePathEnd(codePath) {
-                newCurrentCodePath = codePath.upper;
-                newCurrentSegments = allCurrentSegments.pop();
+                currentCodePath = codePath.upper;
+                currentSegments = allCurrentSegments.pop();
             },
 
             onCodePathSegmentStart(segment) {
-                newCurrentSegments.add(segment);
+                currentSegments.add(segment);
             },
 
             onCodePathSegmentEnd(segment) {
-                newCurrentSegments.delete(segment);
+                currentSegments.delete(segment);
             },
 
             onUnreachableCodePathSegmentStart(segment) {
-                newCurrentSegments.add(segment);
+                currentSegments.add(segment);
             },
 
             onUnreachableCodePathSegmentEnd(segment) {
-                newCurrentSegments.delete(segment);
+                currentSegments.delete(segment);
             }
         };
 

--- a/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
+++ b/src/content/blog/2023-09-26-preparing-custom-rules-eslint-v9.md
@@ -25,18 +25,18 @@ npx codemod @eslint/v8-to-v9-custom-rules
 
 **Important:** Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that export functions.
 
-The codemod supports both CommonJS (`module.exports = function (context) { ... }`) and ES Modules (`export default function (context) { ... }`) export styles.
+The codemod supports CommonJS (`module.exports = function (context) { ... }`), ES Modules (`export default function (context) { ... }`), indirect exports (`function rule() {}` and `module.exports = rule`), higher-order wrappers such as `wrapRule(function (context) { ... })`, and rules created with `@typescript-eslint/utils` `RuleCreator`.
 
 ### What the codemod handles
 
 The codemod performs a comprehensive migration of custom ESLint rules from v8 to v9, including:
 
 * **Removed `context` methods** — migrates calls to `sourceCode` equivalents (for example, `context.getSource()` → `sourceCode.getText()`)
-* **Removed `sourceCode.getComments()`** — converts to a combination of `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()`
+* **Removed `context.getComments()`** — converts node-specific calls to `getCommentsBefore/Inside/After(node)`
 * **Removed `CodePath#currentSegments`** — adds code path tracking logic
 * **Function-style rules are no longer supported** — converts to the object format with `meta` and `create`
 
-The codemod also detects fixable rules and adds `fixable: "code"` to `meta`.
+The codemod also moves `module.exports.schema` into `meta`, converts old-style `context.report(node, message)` calls to object format, detects fixable rules, and adds `fixable: "code"` to `meta`.
 
 Not every change can be fully automated, though. After running the codemod, review your migrated files and consult the sections below for anything that still needs manual attention. For a complete list of breaking changes, see the [ESLint v9 migration guide](/docs/latest/use/migrate-to-9.0.0).
 
@@ -47,24 +47,19 @@ Not every change can be fully automated, though. After running the codemod, revi
     | TODO comment | Action required |
     | --- | --- |
     | `// TODO: Define schema - this rule uses context.options` | Define a proper JSON schema for your rule's options |
-    | `/* TODO: new node param */` | Add the `node` parameter to `getAncestors(node)` or `getScope(node)` |
-    | `/* TODO: new name, node params */` | Update `markVariableAsUsed(name, node)` with the correct parameters |
 
 2. **Fix schemas for rules using options.** If your rule uses `context.options`, you must define the schema manually. The codemod may leave a placeholder like `schema: [] // TODO: Define schema - this rule uses context.options` that you need to replace with a valid JSON schema.
 
-3. **Verify method signature changes.** The codemod replaces these methods automatically, but you need to confirm the `node` parameter is correct:
+3. **Review comment method changes.** `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()` require a `node` argument, and no-argument `context.getComments()` calls should use `sourceCode.getAllComments()`:
 
     | Removed on `context` | Replacement on `SourceCode` |
     | --- | --- |
-    | `context.getAncestors()` | `sourceCode.getAncestors(node)` |
-    | `context.getScope()` | `sourceCode.getScope(node)` |
-    | `context.markVariableAsUsed(name)` | `sourceCode.markVariableAsUsed(name, node)` |
-    | `context.getDeclaredVariables(node)` | `sourceCode.getDeclaredVariables(node)` |
-    | `context.getSource(node)` | `sourceCode.getText(node)` |
-    | `context.getSourceLines()` | `sourceCode.getLines()` |
-    | `context.getComments()` | `sourceCode.getCommentsBefore()`, `getCommentsInside()`, or `getCommentsAfter()` |
+    | `context.getAllComments()` | `sourceCode.getAllComments()` |
+    | `context.getComments(node)` | `sourceCode.getCommentsBefore/Inside/After(node)` |
 
-4. **Test your custom rules** by running your rule test suite (for example, `npm test`).
+4. **Review skipped higher-order wrappers.** If a wrapper passes configuration as the second argument (for example, `wrapRule(rule, config)`), confirm whether any manual migration is needed.
+
+5. **Test your custom rules** by running your rule test suite (for example, `npm test`).
 
 Below is a complete list of the API changes and recommended ways to address them manually if you prefer not to use the codemod.
 
@@ -79,7 +74,7 @@ As we look towards the API we'd like rules for other languages to have, we decid
 |`context.getPhysicalFilename()`|`context.physicalFilename`|
 |`context.getCwd()`|`context.cwd`|
 
-We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. The `@eslint/v8-to-v9-custom-rules` codemod does not cover these changes because they are not removed until ESLint v10.0.0. Here's an example that ensures the correct value is used:
+We are deprecating the methods in favor of the properties (added in v8.40.0). These methods will be removed in v10.0.0 (not v9.0.0) as they are not blocking language plugins work. The `@eslint/v8-to-v9-custom-rules` codemod handles these changes with fallbacks. Here's an example that ensures the correct value is used:
 
 ```js
 module.exports = {
@@ -113,7 +108,7 @@ All of this is to say that we are deprecating all of the code-related methods on
 |`context.getSourceLines()`|`sourceCode.getLines()`|
 |`context.getAllComments()`|`sourceCode.getAllComments()`|
 |`context.getNodeByRangeIndex()`|`sourceCode.getNodeByRangeIndex()`|
-|`context.getComments()`|`sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, `sourceCode.getCommentsInside()`|
+|`context.getComments(node)`|`sourceCode.getCommentsBefore(node)`, `sourceCode.getCommentsAfter(node)`, `sourceCode.getCommentsInside(node)`|
 |`context.getCommentsBefore()`|`sourceCode.getCommentsBefore()`|
 |`context.getCommentsAfter()`|`sourceCode.getCommentsAfter()`|
 |`context.getCommentsInside()`|`sourceCode.getCommentsInside()`|
@@ -139,7 +134,7 @@ In addition to the methods in this table, there are several other methods that a
 
 The `context.getScope()` method is used to retrieve a scope object for the currently-traversed node. This method was always a bit strange because it uses ESLint's internal traversal state to determine which node to use as a reference point to retrieve a scope object. That meant it was both limited, because you couldn't change the reference node, and confusing, because it wasn't always clear what node was being referenced. So, we are deprecating this method and will remove it in ESLint v9.0.0.
 
-We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. The codemod migrates `context.getScope()` calls but leaves a TODO comment where you need to verify the `node` parameter. For best compatibility, you can check for the presence of this new method to determine which one to use:
+We have introduced a new `SourceCode#getScope(node)` method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. The codemod migrates `context.getScope()` calls directly to `sourceCode.getScope(node)`. For best compatibility, you can check for the presence of this new method to determine which one to use:
 
 ```js
 module.exports = {
@@ -162,7 +157,7 @@ module.exports = {
 
 ### `context.getAncestors()`
 
-The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. The codemod migrates `context.getAncestors()` calls but leaves a TODO comment where you need to verify the `node` parameter. Here is an example that checks for the correct method to use:
+The `context.getAncestors()` method is another method on `context` that uses the internal traversal state to return the ancestors of the currently visited node. Also similar to `context.getScope()`, this meant the method was both limited and unclear. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#getAncestors(node)` (added in v8.38.0), which requires you to pass in the node whose ancestors you want to retrieve. The codemod migrates `context.getAncestors()` calls with a compatibility fallback. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -208,7 +203,7 @@ module.exports = {
 
 ### `context.markVariableAsUsed(name)`
 
-The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) The codemod migrates `context.markVariableAsUsed()` calls but leaves a TODO comment where you need to verify the `name` and `node` parameters. Here is an example that checks for the correct method to use:
+The `context.markVariableAsUsed(name)` method finds a variable with the given name in the current scope and marks it as used so it won't cause a violation in the `no-unused-vars` rule. This method has quite a bit of magic going on behind the scenes, as it uses the currently visited node in the traversal to retrieve a scope and then searches that scope for a variable with the given name. We are deprecating this method and will remove it in v9.0.0. The replacement method is `SourceCode#markVariableAsUsed(name, node)` (added in v8.39.0) and requires you to pass in the reference node for the scope to search. (The scope ends up being the same as calling `SourceCode#getScope(node)`.) The codemod migrates `context.markVariableAsUsed()` calls automatically. Here is an example that checks for the correct method to use:
 
 ```js
 module.exports = {
@@ -245,10 +240,10 @@ module.exports = {
     create(context) {
 
         // tracks the code path we are currently in
-        let currentCodePath;
+        let newCurrentCodePath;
 
         // tracks the segments we've traversed in the current code path
-        let currentSegments;
+        let newCurrentSegments;
 
         // tracks all current segments for all open paths
         const allCurrentSegments = [];
@@ -256,30 +251,30 @@ module.exports = {
         return {
 
             onCodePathStart(codePath) {
-                currentCodePath = codePath;
-                allCurrentSegments.push(currentSegments);
-                currentSegments = new Set();
+                newCurrentCodePath = codePath;
+                allCurrentSegments.push(newCurrentSegments);
+                newCurrentSegments = new Set();
             },
 
             onCodePathEnd(codePath) {
-                currentCodePath = codePath.upper;
-                currentSegments = allCurrentSegments.pop();
+                newCurrentCodePath = codePath.upper;
+                newCurrentSegments = allCurrentSegments.pop();
             },
 
             onCodePathSegmentStart(segment) {
-                currentSegments.add(segment);
+                newCurrentSegments.add(segment);
             },
 
             onCodePathSegmentEnd(segment) {
-                currentSegments.delete(segment);
+                newCurrentSegments.delete(segment);
             },
 
             onUnreachableCodePathSegmentStart(segment) {
-                currentSegments.add(segment);
+                newCurrentSegments.add(segment);
             },
 
             onUnreachableCodePathSegmentEnd(segment) {
-                currentSegments.delete(segment);
+                newCurrentSegments.delete(segment);
             }
         };
 

--- a/src/content/blog/2024-05-31-eslint-configuration-migrator.md
+++ b/src/content/blog/2024-05-31-eslint-configuration-migrator.md
@@ -11,17 +11,7 @@ categories:
   - Announcements
 ---
 
-**Update:** ESLint has introduced a new codemod workflow for migrating ESLint v8 configuration to ESLint v9 flat config. You can run it with:
-
-```shell
-npx codemod @eslint/v8-to-v9-config
-```
-
-Unlike the original configuration migrator described below, this codemod runs as a workspace migration. It can extract `eslintConfig` from `package.json`, generate `eslint.config.mjs`, clean up duplicate `/* eslint */` comments and invalid `/* exported */` comments in source files, and remove deprecated `require-jsdoc` and `valid-jsdoc` rule references from inline comments. It also migrates those JSDoc rules to `eslint-plugin-jsdoc` using `jsdoc({ config: "flat/recommended", ... })`, and adds a `// TODO: Migrate settings manually` comment when custom settings need review.
-
-The codemod handles several ESLint v9 rule option changes, including `no-unused-vars`, `no-useless-computed-key`, `no-sequences`, `no-constructor-return`, `camelcase`, and `no-restricted-imports`. It also converts `env` to `languageOptions.globals` using the `globals` package, maps `excludedFiles` to per-config `ignores`, moves `noInlineConfig` and `reportUnusedDisableDirectives` to `linterOptions`, imports parser packages and plugins, uses `defineConfig` and `globalIgnores` from `@eslint/config-helpers`, and merges ignore patterns from both `.eslintignore` and `.gitignore`.
-
-For JavaScript config files, the codemod works from the AST and can resolve simple bindings such as `const` values, identifiers, and spreads. More advanced logic, such as functions, conditionals, and dynamic `require()` calls, still needs manual review. The workflow also supports options such as `--target`, `eslintConfigCustomName`, and `codeFormattingCommandEnabled`, and prompts you to install required packages after it runs. The codemod does not migrate `--ext` CLI usage, so keep the manual step described in [Limitations](#limitations). Learn more in the [eslint/codemods](https://github.com/eslint/codemods) repository and on the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+**Update:** We have partnered with Codemod to make migration easier. Read about the new approach in [this blog post](#TODO-final-url).
 
 We've heard you: One of the biggest reasons ESLint users haven't upgraded to ESLint v9.x is migrating a configuration file seems difficult and complicated. Some plugins support flat config and the ESLint v9.x rule APIs and some don't. Sometimes you need to use [`FlatCompat`](https://github.com/eslint/eslintrc?tab=readme-ov-file#usage-esm) and sometimes you need to use the [compatibility utilities](https://eslint.org/blog/2024/05/eslint-compatibility-utilities/). While we cover as much as we can in the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide), it can take time to walk through your configuration and make the necessary changes.
 
@@ -69,7 +59,7 @@ After generating a configuration file, you should review the following:
 
 * **Are there more recent versions of plugins?** It's possible that there's a newer version of a plugin that fully supports ESLint v9.x on its own and doesn't require any kind of compatibility work. It's always best to upgrade to the latest version of the plugins you use.
 * **Do you have `.eslintrc.*` config files in other directories?** The new configuration system doesn't merge configuration files from ancestor directories. If you are using `.eslintrc.*` files to override configuration in specific directories, you'll need to move that configuration into your primary `eslint.config.*` file.
-* **Were you using the `--ext` CLI flag?** If so, you'll need to [create an entry](https://github.com/eslint/rewrite/tree/main/packages/migrate-config#--ext) in your configuration file to match the file extensions you use to pass on the command line. The `@eslint/v8-to-v9-config` codemod doesn't migrate this CLI flag, either.
+* **Were you using the `--ext` CLI flag?** If so, you'll need to [create an entry](https://github.com/eslint/rewrite/tree/main/packages/migrate-config#--ext) in your configuration file to match the file extensions you use to pass on the command line.
 
 It's possible that the generated configuration file won't work without some modification, but it should get you very close.
 

--- a/src/content/blog/2024-05-31-eslint-configuration-migrator.md
+++ b/src/content/blog/2024-05-31-eslint-configuration-migrator.md
@@ -11,6 +11,14 @@ categories:
   - Announcements
 ---
 
+**Update:** ESLint has introduced a new codemod for migrating ESLint configuration. You can run it with:
+
+```shell
+npx codemod @eslint/v8-to-v9-config
+```
+
+The codemod automatically migrates ESLint v8 configuration files to ESLint v9 flat config format, updating config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible. Learn more in the [eslint/codemods](https://github.com/eslint/codemods) repository and on the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+
 We've heard you: One of the biggest reasons ESLint users haven't upgraded to ESLint v9.x is migrating a configuration file seems difficult and complicated. Some plugins support flat config and the ESLint v9.x rule APIs and some don't. Sometimes you need to use [`FlatCompat`](https://github.com/eslint/eslintrc?tab=readme-ov-file#usage-esm) and sometimes you need to use the [compatibility utilities](https://eslint.org/blog/2024/05/eslint-compatibility-utilities/). While we cover as much as we can in the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide), it can take time to walk through your configuration and make the necessary changes.
 
 That's why we're excited to announce the release of the [ESLint Configuration Migrator](https://npmjs.com/package/@eslint/migrate-config). This utility is designed to translate `.eslintrc.*` files into `eslint.config.js` files, including:

--- a/src/content/blog/2024-05-31-eslint-configuration-migrator.md
+++ b/src/content/blog/2024-05-31-eslint-configuration-migrator.md
@@ -11,13 +11,17 @@ categories:
   - Announcements
 ---
 
-**Update:** ESLint has introduced a new codemod for migrating ESLint configuration. You can run it with:
+**Update:** ESLint has introduced a new codemod workflow for migrating ESLint v8 configuration to ESLint v9 flat config. You can run it with:
 
 ```shell
 npx codemod @eslint/v8-to-v9-config
 ```
 
-The codemod automatically migrates ESLint v8 configuration files to ESLint v9 flat config format, updating config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible. Learn more in the [eslint/codemods](https://github.com/eslint/codemods) repository and on the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+Unlike the original configuration migrator described below, this codemod runs as a workspace migration. It can extract `eslintConfig` from `package.json`, generate `eslint.config.mjs`, clean up duplicate `/* eslint */` comments and invalid `/* exported */` comments in source files, and remove deprecated `require-jsdoc` and `valid-jsdoc` rule references from inline comments. It also migrates those JSDoc rules to `eslint-plugin-jsdoc` using `jsdoc({ config: "flat/recommended", ... })`, and adds a `// TODO: Migrate settings manually` comment when custom settings need review.
+
+The codemod handles several ESLint v9 rule option changes, including `no-unused-vars`, `no-useless-computed-key`, `no-sequences`, `no-constructor-return`, `camelcase`, and `no-restricted-imports`. It also converts `env` to `languageOptions.globals` using the `globals` package, maps `excludedFiles` to per-config `ignores`, moves `noInlineConfig` and `reportUnusedDisableDirectives` to `linterOptions`, imports parser packages and plugins, uses `defineConfig` and `globalIgnores` from `@eslint/config-helpers`, and merges ignore patterns from both `.eslintignore` and `.gitignore`.
+
+For JavaScript config files, the codemod works from the AST and can resolve simple bindings such as `const` values, identifiers, and spreads. More advanced logic, such as functions, conditionals, and dynamic `require()` calls, still needs manual review. The workflow also supports options such as `--target`, `eslintConfigCustomName`, and `codeFormattingCommandEnabled`, and prompts you to install required packages after it runs. The codemod does not migrate `--ext` CLI usage, so keep the manual step described in [Limitations](#limitations). Learn more in the [eslint/codemods](https://github.com/eslint/codemods) repository and on the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
 
 We've heard you: One of the biggest reasons ESLint users haven't upgraded to ESLint v9.x is migrating a configuration file seems difficult and complicated. Some plugins support flat config and the ESLint v9.x rule APIs and some don't. Sometimes you need to use [`FlatCompat`](https://github.com/eslint/eslintrc?tab=readme-ov-file#usage-esm) and sometimes you need to use the [compatibility utilities](https://eslint.org/blog/2024/05/eslint-compatibility-utilities/). While we cover as much as we can in the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide), it can take time to walk through your configuration and make the necessary changes.
 
@@ -65,7 +69,7 @@ After generating a configuration file, you should review the following:
 
 * **Are there more recent versions of plugins?** It's possible that there's a newer version of a plugin that fully supports ESLint v9.x on its own and doesn't require any kind of compatibility work. It's always best to upgrade to the latest version of the plugins you use.
 * **Do you have `.eslintrc.*` config files in other directories?** The new configuration system doesn't merge configuration files from ancestor directories. If you are using `.eslintrc.*` files to override configuration in specific directories, you'll need to move that configuration into your primary `eslint.config.*` file.
-* **Were you using the `--ext` CLI flag?** If so, you'll need to [create an entry](https://github.com/eslint/rewrite/tree/main/packages/migrate-config#--ext) in your configuration file to match the file extensions you use to pass on the command line.
+* **Were you using the `--ext` CLI flag?** If so, you'll need to [create an entry](https://github.com/eslint/rewrite/tree/main/packages/migrate-config#--ext) in your configuration file to match the file extensions you use to pass on the command line. The `@eslint/v8-to-v9-config` codemod doesn't migrate this CLI flag, either.
 
 It's possible that the generated configuration file won't work without some modification, but it should get you very close.
 

--- a/src/content/drafts/eslint-codemod-migration-codemods.md
+++ b/src/content/drafts/eslint-codemod-migration-codemods.md
@@ -12,25 +12,87 @@ categories:
   - Announcements
 ---
 
-We are excited to announce a partnership between ESLint and [Codemod](https://codemod.com), an [OpenJS Foundation](https://openjsf.org) partner, to create a better migration experience for ESLint users, starting with the ESLint v8 to v9 and v9 to v10 migrations. All official ESLint codemods can be found in the [eslint/codemods](https://github.com/eslint/codemods) repo, and through the [Codemod Registry](https://codemod.link/eslint).
+We are excited to announce a partnership between ESLint and [Codemod](https://codemod.com) to create a better migration experience for ESLint users, starting with the ESLint v8 to v9 and v9 to v10 migrations. All official ESLint codemods live in [eslint/codemods](https://github.com/eslint/codemods) and on the [Codemod Registry](https://codemod.link/eslint). Community members are encouraged to open issues for missing codemods or contribute new ones through pull requests. Once reviewed and merged by maintainers, codemods are automatically published to the Codemod Registry through GitHub Actions.
+
+## What is Codemod?
+
+Codemod is an open source platform for building, sharing, and running automated code migrations at scale. It is an [OpenJS Foundation](https://openjsf.org) partner, and its tooling has been adopted by projects such as React, Node.js, Express, React Router, Nuxt.js, pnpm, Webpack, MSW, i18next, and more.
+
+Its platform includes JSSG (JS ast-grep), a codemod runtime and workflow engine that supports multi-step transformations and combines deterministic, compiler-aware transformations with AI-powered steps to deliver the right balance of reliability, efficiency, and flexibility. The source code for the Codemod CLI and engine is available on [GitHub](https://github.com/codemod/codemod).
+
+Key features of Codemod include:
+
+* Workspace-wide semantic analysis
+* Cross-file refactors
+* Multi-language support
+* Repository-scale performance
+* A simple, agent-friendly API
+* Built-in AST inspection through MCP
+* Secure sandboxed execution
+* Metrics and codebase mining
+* Native support for multi-file transformations
+
+Check out the [Codemod docs](https://docs.codemod.com) to learn more about JSSG (JS ast-grep), Codemod's open source toolkit for building codemods, and explore its features.
 
 ## ESLint v8 to v9 migration
 
-For v8 to v9 migration, we've released two codemods: one to help upgrade ESLint config, and another for the custom rules:
+For v8 to v9 migration, we've released two codemods: one to help upgrade ESLint config, and another for custom rules.
+
+### Migrating configuration with `@eslint/v8-to-v9-config`
 
 ```shell
 npx codemod @eslint/v8-to-v9-config
 ```
 
-This codemod automatically migrates ESLint v8 configuration files to ESLint v9 flat config format, updating config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible. learn more [here](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+Unlike the original [ESLint Configuration Migrator](https://npmjs.com/package/@eslint/migrate-config), this codemod runs as a workspace migration. It can:
+
+* Extract `eslintConfig` from `package.json` and generate `eslint.config.mjs`
+* Clean up duplicate `/* eslint */` comments and invalid `/* exported */` comments in source files
+* Remove deprecated `require-jsdoc` and `valid-jsdoc` rule references from inline comments
+* Migrate those JSDoc rules to [`eslint-plugin-jsdoc`](https://www.npmjs.com/package/eslint-plugin-jsdoc) using `jsdoc({ config: "flat/recommended", ... })`
+* Add a `// TODO: Migrate settings manually` comment when custom settings need review
+* Handle several ESLint v9 rule option changes, including `no-unused-vars`, `no-useless-computed-key`, `no-sequences`, `no-constructor-return`, `camelcase`, and `no-restricted-imports`
+* Convert `env` to `languageOptions.globals` using the [`globals`](https://www.npmjs.com/package/globals) package
+* Map `excludedFiles` to per-config `ignores`
+* Move `noInlineConfig` and `reportUnusedDisableDirectives` to `linterOptions`
+* Import parser packages and plugins
+* Use `defineConfig` and `globalIgnores` from [`@eslint/config-helpers`](https://www.npmjs.com/package/@eslint/config-helpers)
+* Merge ignore patterns from both `.eslintignore` and `.gitignore`
+
+For JavaScript config files, the codemod works from the AST and can resolve simple bindings such as `const` values, identifiers, and spreads. More advanced logic, such as functions, conditionals, and dynamic `require()` calls, still needs manual review. The workflow also supports options such as `--target`, `eslintConfigCustomName`, and `codeFormattingCommandEnabled`, and prompts you to install required packages after it runs.
+
+The codemod does not migrate `--ext` CLI usage, so you still need to [create a config entry](https://github.com/eslint/rewrite/tree/main/packages/migrate-config#--ext) for the file extensions you previously passed on the command line. Learn more on [`@eslint/v8-to-v9-config`'s registry page](https://app.codemod.com/registry/@eslint/v8-to-v9-config) and in the [configuration migration guide](/docs/latest/use/configure/migration-guide).
+
+### Migrating custom rules with `@eslint/v8-to-v9-custom-rules`
 
 ```shell
 npx codemod @eslint/v8-to-v9-custom-rules
 ```
 
-This codemod migrates custom ESLint rules from v8 to v9 by converting function-style rules to the new object format and updating deprecated rule APIs to their ESLint v9-compatible equivalents. Learn more [here](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules).
+**Important:** Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that export functions.
 
-For more details about what's new in v9 and how to adopt the new features, refer to the [official ESLint upgrade guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0), and the [blog post for v9 custom rules](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/).
+The codemod supports CommonJS (`module.exports = function (context) { ... }`), ES Modules (`export default function (context) { ... }`), indirect exports (`function rule() {}` and `module.exports = rule`), higher-order wrappers such as `wrapRule(function (context) { ... })`, and rules created with `@typescript-eslint/utils` `RuleCreator`.
+
+It performs a comprehensive migration of custom ESLint rules from v8 to v9, including:
+
+* **Removed `context` methods** — migrates calls to `sourceCode` equivalents (for example, `context.getSource()` → `sourceCode.getText()`), including methods that moved with different signatures such as `getScope()`, `getAncestors()`, `getDeclaredVariables()`, and `markVariableAsUsed()`
+* **`context` methods becoming properties** — migrates `getSourceCode()`, `getFilename()`, `getPhysicalFilename()`, and `getCwd()` to their property equivalents with compatibility fallbacks
+* **Removed `context.getComments()`** — converts node-specific calls to `getCommentsBefore` / `getCommentsInside` / `getCommentsAfter(node)`
+* **Removed `CodePath#currentSegments`** — adds code path tracking logic (verify the result matches your rule's needs)
+* **Function-style rules are no longer supported** — converts to the object format with `meta` and `create`
+
+The codemod also moves `module.exports.schema` into `meta`, converts old-style `context.report(node, message)` calls to object format, detects fixable rules, and adds `fixable: "code"` to `meta`.
+
+It does **not** cover `context.parserOptions` and `context.parserPath`, because those properties are not removed until ESLint v10.0.0. Prefer `context.languageOptions` (and `context.languageOptions.parser` when you need the parser) instead.
+
+Not every change can be fully automated. After running the codemod:
+
+1. **Review TODO comments.** Search for `TODO` in your migrated files. If a rule uses `context.options`, the codemod may leave a placeholder like `schema: [] // TODO: Define schema - this rule uses context.options` that you need to replace with a valid JSON schema.
+2. **Review comment method changes.** `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()` require a `node` argument, and no-argument `context.getComments()` calls should use `sourceCode.getAllComments()`.
+3. **Review skipped higher-order wrappers.** If a wrapper passes configuration as the second argument (for example, `wrapRule(rule, config)`), confirm whether any manual migration is needed.
+4. **Test your custom rules** by running your rule test suite (for example, `npm test`).
+
+Learn more on [`@eslint/v8-to-v9-custom-rules`'s registry page](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules). For the full list of API changes and how to adopt them manually, see the [ESLint v9 migration guide](/docs/latest/use/migrate-to-9.0.0) and the [blog post for v9 custom rules](/blog/2023/09/preparing-custom-rules-eslint-v9/).
 
 ## ESLint v9 to v10 migration
 
@@ -49,24 +111,8 @@ This recipe includes four individual codemods, each of which can also be run ind
 
 Check out [Codemod Registry](https://codemod.link/eslint) to learn more about this recipe and its codemods. For more details about what's new in v10 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-10.0.0).
 
-### About Codemod
+## Conclusion
 
-Codemod is an open source platform for building, sharing, and running automated code migrations at scale. Its platform includes JSSG, a codemod runtime and workflow engine that supports multi-step transformations and combines deterministic, compiler-aware transformations with AI-powered steps to deliver the right balance of reliability, efficiency, and flexibility.
+Upgrading across major ESLint versions has often meant carefully translating configs, custom rules, and related APIs by hand. With this partnership, official Codemod workflows give you a faster starting point for the v8 to v9 and v9 to v10 migrations, while still leaving room for the manual review steps that complex projects need.
 
-Codemod is an OpenJS Foundation partner, and its tooling has been adopted by projects such as React, Node.js, Express, React Router, Nuxt.js, pnpm, Webpack, MSW, i18next, and many other open source projects. The source code for the Codemod CLI and engine is available on [GitHub](https://github.com/codemod-com/codemod).
-
-The ESLint codemods will live in [eslint/codemods](https://github.com/eslint/codemods). Community members are encouraged to open issues for missing codemods or contribute new ones through pull requests. Once reviewed and merged by maintainers, codemods are automatically published to the Codemod Registry through GitHub Actions.
-
-### Key features of the Codemod open source toolkit
-
-* Workspace-wide semantic analysis
-* Cross-file refactors
-* Multi-language support
-* Repository-scale performance
-* A simple, agent-friendly API
-* Built-in AST inspection through MCP
-* Secure sandboxed execution
-* Metrics and codebase mining
-* Native support for multi-file transformations
-
-Check out [Codemod docs](https://docs.codemod.com) to learn more about JSSG and its features.
+You can try the codemods today through the [Codemod Registry](https://codemod.link/eslint), and find the source in [eslint/codemods](https://github.com/eslint/codemods). If you run into a gap, open an issue or contribute a new codemod. For questions about the migrations themselves, see the [v9](/docs/latest/use/migrate-to-9.0.0) and [v10](/docs/latest/use/migrate-to-10.0.0) upgrade guides, or stop by [Discord](https://eslint.org/chat) to talk with the team.

--- a/src/content/drafts/eslint-codemod-migration-codemods.md
+++ b/src/content/drafts/eslint-codemod-migration-codemods.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ESLint partners with Codemod on official migration codemods
-teaser: "ESLint and Codemod are partnering to deliver official codemods for upgrading from ESLint v8 to v9 and v9 to v10."
+teaser: "ESLint and Codemod are partnering to deliver official codemods for ESLint migrations."
 tags:
   - Migration
   - Codemods
@@ -12,21 +12,25 @@ categories:
   - Announcements
 ---
 
-We are excited to announce a partnership between ESLint and [Codemod](https://codemod.com), an [OpenJS Foundation](https://openjsf.org) partner, to create a better migration experience for ESLint users, starting with the ESLint v8 to v9 and v9 to v10 migrations. All official ESLint codemods can be found in the [eslint/codemods](https://github.com/eslint/codemods) repo, and through the [Codemod Registry](https://codemod.com/registry).
+We are excited to announce a partnership between ESLint and [Codemod](https://codemod.com), an [OpenJS Foundation](https://openjsf.org) partner, to create a better migration experience for ESLint users, starting with the ESLint v8 to v9 and v9 to v10 migrations. All official ESLint codemods can be found in the [eslint/codemods](https://github.com/eslint/codemods) repo, and through the [Codemod Registry](https://codemod.link/eslint).
 
 ## ESLint v8 to v9 migration
 
-We've released two codemods: one to help upgrade ESLint v8 to v9, and another for ESLint custom rules:
+For v8 to v9 migration, we've released two codemods: one to help upgrade ESLint config, and another for the custom rules:
 
 ```shell
 npx codemod @eslint/v8-to-v9-config
 ```
 
+This codemod automatically migrates ESLint v8 configuration files to ESLint v9 flat config format, updating config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible. learn more [here](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+
 ```shell
 npx codemod @eslint/v8-to-v9-custom-rules
 ```
 
-For more details about what's new in v9 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-9.0.0), and the [blog post for v9 custom rules](/blog/2023/09/preparing-custom-rules-eslint-v9).
+This codemod migrates custom ESLint rules from v8 to v9 by converting function-style rules to the new object format and updating deprecated rule APIs to their ESLint v9-compatible equivalents. Learn more [here](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules).
+
+For more details about what's new in v9 and how to adopt the new features, refer to the [official ESLint upgrade guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0), and the [blog post for v9 custom rules](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/).
 
 ## ESLint v9 to v10 migration
 
@@ -43,7 +47,7 @@ This recipe includes four individual codemods, each of which can also be run ind
 * `@eslint/v9-to-v10-ruletester`: Cleanup RuleTester test cases
 * `@eslint/v9-to-v10-linter-api`: Fix Linter/ESLint API usage
 
-For more details about what's new in v10 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-10.0.0).
+Check out [Codemod Registry](https://codemod.link/eslint) to learn more about this recipe and its codemods. For more details about what's new in v10 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-10.0.0).
 
 ### About Codemod
 

--- a/src/content/drafts/eslint-codemod-migration-codemods.md
+++ b/src/content/drafts/eslint-codemod-migration-codemods.md
@@ -1,0 +1,68 @@
+---
+layout: post
+title: ESLint partners with Codemod on official migration codemods
+teaser: "ESLint and Codemod are partnering to deliver official codemods for upgrading from ESLint v8 to v9 and v9 to v10."
+tags:
+  - Migration
+  - Codemods
+  - Tools
+authors:
+  - alexbit-codemod
+categories:
+  - Announcements
+---
+
+We are excited to announce a partnership between ESLint and [Codemod](https://codemod.com), an [OpenJS Foundation](https://openjsf.org) partner, to create a better migration experience for ESLint users, starting with the ESLint v8 to v9 and v9 to v10 migrations. All official ESLint codemods can be found in the [eslint/codemods](https://github.com/eslint/codemods) repo, and through the [Codemod Registry](https://codemod.com/registry).
+
+## ESLint v8 to v9 migration
+
+We've released two codemods: one to help upgrade ESLint v8 to v9, and another for ESLint custom rules:
+
+```shell
+npx codemod @eslint/v8-to-v9-config
+```
+
+```shell
+npx codemod @eslint/v8-to-v9-custom-rules
+```
+
+For more details about what's new in v9 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-9.0.0), and the [blog post for v9 custom rules](/blog/2023/09/preparing-custom-rules-eslint-v9).
+
+## ESLint v9 to v10 migration
+
+Upgrade your ESLint project from v9 to v10 with the following codemod:
+
+```shell
+npx codemod @eslint/v9-to-v10
+```
+
+This recipe includes four individual codemods, each of which can also be run independently:
+
+* `@eslint/v9-to-v10-config`: Remove legacy env vars and CLI flags
+* `@eslint/v9-to-v10-custom-rules`: Replace removed context and SourceCode methods
+* `@eslint/v9-to-v10-ruletester`: Cleanup RuleTester test cases
+* `@eslint/v9-to-v10-linter-api`: Fix Linter/ESLint API usage
+
+For more details about what's new in v10 and how to adopt the new features, refer to the [official ESLint upgrade guide](/docs/latest/use/migrate-to-10.0.0).
+
+### About Codemod
+
+Codemod is an open source platform for building, sharing, and running automated code migrations at scale. Its platform includes JSSG, a codemod runtime and workflow engine that supports multi-step transformations and combines deterministic, compiler-aware transformations with AI-powered steps to deliver the right balance of reliability, efficiency, and flexibility.
+
+Codemod is an OpenJS Foundation partner, and its tooling has been adopted by projects such as React, Node.js, Express, React Router, Nuxt.js, pnpm, Webpack, MSW, i18next, and many other open source projects. The source code for the Codemod CLI and engine is available on [GitHub](https://github.com/codemod-com/codemod).
+
+The ESLint codemods will live in [eslint/codemods](https://github.com/eslint/codemods). Community members are encouraged to open issues for missing codemods or contribute new ones through pull requests. Once reviewed and merged by maintainers, codemods are automatically published to the Codemod Registry through GitHub Actions.
+
+### Key features of the Codemod open source toolkit
+
+* Workspace-wide semantic analysis
+* Cross-file refactors
+* Multi-language support
+* Repository-scale performance
+* A simple, agent-friendly API
+* Built-in AST inspection through MCP
+* Secure sandboxed execution
+* Metrics and codebase mining
+* Native support for multi-file transformations
+
+Check out [Codemod docs](https://docs.codemod.com) to learn more about JSSG and its features.

--- a/src/content/drafts/eslint-codemod-migration-codemods.md
+++ b/src/content/drafts/eslint-codemod-migration-codemods.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: ESLint partners with Codemod on official migration codemods
+title: Automating ESLint migrations with Codemod
 teaser: "ESLint and Codemod are partnering to deliver official codemods for ESLint migrations."
 tags:
   - Migration


### PR DESCRIPTION
## Summary

- Add a draft blog post announcing the partnership between ESLint and Codemod to deliver official migration codemods (`@eslint/v8-to-v9-config`, `@eslint/v8-to-v9-custom-rules`, and `@eslint/v9-to-v10`, including the individual v9-to-v10 recipes)
- Update the existing [Preparing your custom rules for ESLint v9.0.0](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/) post to recommend `@eslint/v8-to-v9-custom-rules` instead of `eslint-transforms`, including what the codemod automates, manual follow-up steps, and per-section codemod coverage notes
- Polish the partnership draft copy (codemod descriptions, registry links, teasers) and update the `alexbit-codemod` author bio

depends on: https://github.com/eslint/eslint/pull/20980

## Test plan

- [x] Run `npm start` and verify the draft partnership post appears at the top of `/blog`
- [x] Confirm the updated 2023 custom rules post renders correctly at `/blog/2023/09/preparing-custom-rules-eslint-v9/`
- [x] Confirm author bio and avatar render correctly for `alexbit-codemod`
- [x] Review links to migration guides, [eslint/codemods](https://github.com/eslint/codemods), and the [Codemod Registry](https://codemod.link/eslint)