### PR TITLE
fix: improve playground alert content alignment

### DIFF
--- a/src/assets/scss/components/alert.scss
+++ b/src/assets/scss/components/alert.scss
@@ -77,8 +77,9 @@
 
 .alert__content {
 	display: flex;
+	align-items: center;
 	flex-wrap: wrap;
-	gap: 0.5rem;
+	gap: 0.75rem 1.5rem;
 	flex: 1;
 	padding: 0.5rem;
 
@@ -90,16 +91,11 @@
 .alert__position {
 	display: flex;
 	align-items: center;
-	margin-right: 1rem;
-	margin-inline-end: 1rem;
+	gap: 0.75rem;
 }
 
 .alert__icon {
 	color: inherit;
-	position: relative;
-	margin-right: 0.75rem;
-	margin-inline-end: 0.75rem;
-	margin-top: -4px;
 }
 
 .alert__actions {
@@ -108,7 +104,6 @@
 
 .alert__line-number {
 	font-weight: 500;
-	margin-bottom: 0.25rem;
 	border-bottom: 1px solid currentColor;
 	padding: 0;
 

--- a/src/playground/components/alert.jsx
+++ b/src/playground/components/alert.jsx
@@ -89,11 +89,10 @@ export default function Alert({
 					<span className="visually-hidden">Error</span>
 					<button
 						className="alert__line-number"
+						aria-label={`Line ${line}, column ${column}`}
 						onClick={() => onPositionClick(message)}
 					>
-						<span className="line-number">{line}</span>
-						{line && column && <span aria-hidden="true">:</span>}
-						<span className="colun-number">{column}</span>
+						{line}:{column}
 					</button>
 				</div>
 				<div className="alert__text">


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR improves the layout and accessibility of playground alert content so the icon, position, and message text align more consistently.

#### What changes did you make? (Give an overview)

- Updated the alert content styles to vertically center items and use `gap` instead of margins for spacing. 
- Removed unused line and column wrapper classes from the alert position text
- Added an accessible label to the position button.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
