### PR TITLE
fix: scroll to playground alert lines reliably

### DIFF
--- a/src/playground/components/code-editor.jsx
+++ b/src/playground/components/code-editor.jsx
@@ -2,6 +2,7 @@ import { useImperativeHandle, useMemo, useRef } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { javascript, esLint } from "@codemirror/lang-javascript";
 import { foldGutter } from "@codemirror/language";
+import { EditorView } from "@codemirror/view";
 import { linter } from "../utils/codemirror-linter-extension";
 import {
 	ESLintPlaygroundTheme,
@@ -50,21 +51,10 @@ export default function CodeEditor({
 			const { state } = editorView;
 			const pos = state.doc.line(line).from + col;
 
-			// Set the cursor selection to the position
 			editorView.dispatch({
 				selection: { anchor: pos },
-				scrollIntoView: true,
+				effects: EditorView.scrollIntoView(pos, { y: "center" }),
 			});
-
-			const linePos = editorView.coordsAtPos(state.doc.line(line).from);
-
-			// Calculate to try to center the line in the editor
-			if (linePos) {
-				const editorRect = editorView.dom.getBoundingClientRect();
-				const offset =
-					linePos.top - editorRect.top - editorRect.height / 2;
-				editorView.scrollDOM.scrollTop += offset;
-			}
 
 			editorView.focus();
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes playground alert line number clicks so they reliably scroll the editor to the reported error.

#### What changes did you make? (Give an overview)

Updated the playground editor to use CodeMirror’s `EditorView.scrollIntoView()` effect with vertical centering when navigating to an alert position. This replaces the previous manual scroll offset calculation.

#### How to reproduce

1. Open the [playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1jb25zdDogXCJlcnJvclwiICovXG5sZXQgYSA9IFwiYlwiO1xuXG5cblxuXG5cblxuXG5cblxuXG5cblxuXG5cblxuXG5cblxuXG5cblxuXG5cblxuXG5cblxuIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19).
2. Scroll down in the editor.
3. Click the alert’s line number in the console.
4. Confirm the editor scrolls back up to the reported line.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
