### PR TITLE
fix: prevent playground scrolling when deprecation notice is present

### DIFF
--- a/src/assets/scss/playground-layout.scss
+++ b/src/assets/scss/playground-layout.scss
@@ -1,4 +1,16 @@
+body.playground-page {
+	height: 100%;
+
+	#main,
+	#playground-app {
+		height: 100%;
+		min-height: 0;
+	}
+}
+
 .playground-wrapper {
+	height: 100%;
+
 	@media all and (min-width: 1023px) {
 		display: grid;
 		grid-template-columns: minmax(0, 3fr) minmax(250px, 1fr);
@@ -11,11 +23,8 @@
 	grid-row: 1;
 	display: flex;
 	flex-direction: column;
-	height: calc(100vh - 77px - 41px);
-
-	@media all and (min-width: 1023px) {
-		height: calc(100vh - 77px);
-	}
+	height: 100%;
+	min-height: 0;
 }
 
 .playground__config-and-footer {
@@ -26,7 +35,7 @@
 	background-color: var(--lightest-background-color);
 
 	@media all and (min-width: 1023px) {
-		height: calc(100vh - 77px);
+		height: 100%;
 		overflow-y: auto;
 		border-left: 1px solid var(--divider-color);
 		border-inline-end: 1px solid var(--divider-color);

--- a/src/content/pages/playground.html
+++ b/src/content/pages/playground.html
@@ -2,6 +2,7 @@
 layout: main.html
 title: ESLint Playground
 permalink: /play/
+hook: "playground_page"
 ---
 
 <div id="playground-app">


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes an issue where the Playground page becomes scrollable whenever the deprecation notice is present at the top of the page. Previously, the height of the playground layout was hardcoded to `calc(100vh - 77px)`. While this subtracted the height of the header, it failed to account for the deprecation notice. When the notice appeared, it pushed the playground down, causing the `100vh` container to overflow and trigger a full-page scrollbar.

#### What changes did you make? (Give an overview)

- Added a `hook: "playground_page"` to the playground page frontmatter to target the playground body.
- Refactored `playground-layout.scss` to use percentage-based heights instead of pixel deductions.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
