### PR TITLE
fix: remove invalid opacity property from lint tooltip

### DIFF
--- a/src/playground/utils/codemirror-linter-extension.jsx
+++ b/src/playground/utils/codemirror-linter-extension.jsx
@@ -203,7 +203,6 @@ function lintTooltip(view, pos, side) {
 function diagnosticsTooltip(view, diagnostics) {
 	return elt(
 		"div",
-		{ style: "opacity: hidden" },
 		diagnostics.map(d => renderDiagnostic(view, d, false)),
 	);
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR removes an invalid `opacity` CSS property from the CodeMirror linter diagnostic tooltips.

#### What changes did you make? (Give an overview)

Removed `{ style: "opacity: hidden" }` from `diagnosticsTooltip`. `"hidden"` is an invalid value for `opacity` and was already being ignored by the browser, so this cleanup has no visual impact.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
