### PR TITLE
ci: skip Node.js 24.17 for data-fetch

### DIFF
--- a/.github/workflows/data-fetch.yml
+++ b/.github/workflows/data-fetch.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: "lts/*"
+        node-version: "^24.18.0"
 
     - name: Install npm packages
       run: npm install


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

`node-version: "lts/*"` currently resolves to 24.17.0 which has a bug (https://github.com/nodejs/node/issues/63989) that affects our data fetch job (https://github.com/eslint/eslint.org/actions/runs/28283160401).

#### What changes did you make? (Give an overview)

Updates to `node-version: "^24.18.0"` to skip 24.17.0. When `node-version: "lts/*"` starts resolving to a version that is >= 24.18.0, we can revert this change.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
