### PR TITLE
fix: add role to homepage stats so their aria-label is not discarded

### DIFF
--- a/src/_includes/components/stat.macro.html
+++ b/src/_includes/components/stat.macro.html
@@ -1,5 +1,5 @@
 {% macro statItem(statValue, statLabel) %}
-<div class="metrics__item" aria-label="{{ (statValue | formatStatsNumber).full}} {{ statLabel }}">
+<div class="metrics__item" role="img" aria-label="{{ (statValue | formatStatsNumber).full}} {{ statLabel }}">
     <span class="metrics__value" aria-hidden="true">{{ (statValue | formatStatsNumber).short }}</span>
     <span aria-hidden="true">{{ statLabel }}</span>
 </div>


### PR DESCRIPTION
The three headline statistics on the homepage are announced as nothing at all by a screen reader. Not read out awkwardly, genuinely skipped.

### Why

`src/_includes/components/stat.macro.html` renders:

```html
<div class="metrics__item" aria-label="27.5 million Dependents">
    <span class="metrics__value" aria-hidden="true">27.5M</span>
    <span aria-hidden="true">Dependents</span>
</div>
```

`aria-label` is prohibited on an element with no role, so assistive technology discards it. Both children are `aria-hidden="true"`, so the visible text is hidden too. Nothing is left. The intent is clearly right, spelling out "27.5 million" instead of "27.5M"; it just gets thrown away.

Affects all three: Dependents, Weekly Downloads, Stars.

axe on https://eslint.org/:

```
rule   : aria-prohibited-attr
impact : serious
tags   : wcag2a, wcag412
nodes  : 3
```

### The fix

Adding `role="img"` makes `aria-label` permitted, and the item is then announced as a single unit, "27.5 million Dependents". One character-level change, no visual change, no CSS change. `role="img"` is the usual choice for a small composite that should be read as one thing rather than walked through.

### Verification

axe against the live homepage, then the same change applied in the page, then axe again:

```
BEFORE: [{"id":"aria-prohibited-attr","nodes":3}]
role="img" applied to: 3
AFTER : []
```

`role="group"` would also clear the rule, but it invites the user to navigate into the group, and the children are hidden, so there is nothing inside to find. `role="img"` matches what the markup is actually doing.

Found with an accessibility checker I maintain. Nothing is being sold here; the two axe runs above reproduce it.