### PR TITLE
fix: prevent null titles in blog search results

### DIFF
--- a/src/_includes/components/hero.macro.html
+++ b/src/_includes/components/hero.macro.html
@@ -15,10 +15,10 @@
 <div class="section hero">
     <div class="content-container grid">
         <div class="span-1-7 content-container">
+            <h1 class="section-title">{{ params.title }}</h1>
             {%- if params.post -%}
                 <p class="post__meta">Published <time datetime="{{ params.post.date }}">{{ params.post.date }}</time> under <a href="/blog/category/{{ params.post.categoryURL }}">{{ params.post.category  }}</a></p>
             {%- endif -%}
-            <h1 class="section-title">{{ params.title }}</h1>
             <p class="section-supporting-text">
                 {{ params.supporting_text | safe }}
             </p>

--- a/src/assets/scss/blog.scss
+++ b/src/assets/scss/blog.scss
@@ -67,6 +67,12 @@ ul.tag-list {
 	gap: 0.5rem;
 }
 
+/* Keep the visual order while placing the title first in the DOM for search indexing. */
+.blog-post-page .hero .span-1-7 {
+	display: flex;
+	flex-direction: column;
+}
+
 .tag-list__item {
 	background-color: var(--lightest-background-color);
 	color: var(--link-color);
@@ -81,6 +87,10 @@ ul.tag-list {
 	font-weight: 500;
 	margin-bottom: 1rem;
 	margin-block-end: 1rem;
+
+	.blog-post-page & {
+		order: -1;
+	}
 }
 
 .post__sidebar-module {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

When searching for `2026` on the ESLint blog, some post titles were displayed as `null`. This happened because the publication information appeared before the post title in the HTML.

Algolia processes HTML from top to bottom during crawling. When it created a record containing keywords such as `Published` and `2026`, it had not yet encountered the `<h1>`, so the title field, `hierarchy.lvl1`, was stored as `null`. As a result, `null` was displayed as the search result title.

#### What changes did you make? (Give an overview)

I changed the order of the HTML processed by Algolia.

Previous DOM:

```html
<p class="post__meta">Published ...</p>
<h1>Post title</h1>
```

Updated DOM:

```html
<h1>Post title</h1>
<p class="post__meta">Published ...</p>
```

As a result:

1. The DOM order processed by Algolia is title -> publication information.
2. The visual order shown to users remains publication information -> title.
3. The existing design is preserved while preventing `null` from appearing as the post title.

#### Related Issues

Fixes #1125

#### Is there anything you'd like reviewers to focus on?

Local search also uses the production Algolia index, so I could not verify the recrawled search results locally. Final verification of the search results requires an Algolia recrawl after deployment.

After the recrawl, please verify that search records for the publication information correctly use the preceding `<h1>` as `hierarchy.lvl1`.

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)