### PR TITLE
fix: ignore whitespace-only blog search queries

### DIFF
--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -193,13 +193,16 @@ const handleDocumentClick = e => {
 searchInput.addEventListener("input", function () {
 	const query = searchInput.value;
 
-	if (query === searchQuery) return;
-
 	if (query.length) searchClearBtn.removeAttribute("hidden");
 	else searchClearBtn.setAttribute("hidden", "");
 
-	if (query.length > 2) {
-		debouncedFetchSearchResults(query);
+	// Trim so that whitespace-only input doesn't trigger a search.
+	const trimmedQuery = query.trim();
+
+	if (trimmedQuery === searchQuery) return;
+
+	if (trimmedQuery.length > 2) {
+		debouncedFetchSearchResults(trimmedQuery);
 		if (!document.clickEventAdded) {
 			document.addEventListener("click", handleDocumentClick);
 			document.clickEventAdded = true;
@@ -208,7 +211,7 @@ searchInput.addEventListener("input", function () {
 		clearSearchResults(true);
 	}
 
-	searchQuery = query;
+	searchQuery = trimmedQuery;
 });
 
 searchClearBtn.addEventListener("click", function () {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Typing only spaces into the blog search passes the minimum-length check and shows a dropdown of unrelated posts.

#### What changes did you make? (Give an overview)

Trim the input before the length check and the request, and compare trimmed queries in the duplicate check so adding or removing surrounding whitespace doesn't re-run the same search.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search behavior by ignoring leading and trailing spaces when checking for duplicate queries and triggering searches.
  - Search results are now less likely to refresh unnecessarily for equivalent queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->