### PR TITLE
fix: default playground theme switcher pressed state to system

### DIFF
--- a/src/playground/components/theme-switcher.jsx
+++ b/src/playground/components/theme-switcher.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 
 export default function ThemeSwitcher() {
-	const [theme, setTheme] = useState(window.localStorage.getItem("theme"));
+	const [theme, setTheme] = useState(
+		() => window.localStorage.getItem("theme") || "system",
+	);
 
 	const toggleTheme = newTheme => {
 		if (newTheme === "system") {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

On a first visit to the playground, none of the Light / System / Dark buttons in the footer shows as pressed. The switcher initializes its state straight from `localStorage.getItem("theme")`, which is `null` until the user clicks a button, so every button renders with `aria-pressed="false"` even though the page is already displayed in the system theme.

#### What changes did you make? (Give an overview)

The component now falls back to `"system"` when no theme is stored.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
